### PR TITLE
Re-adding private cloning support for repository tab repos.

### DIFF
--- a/src/GithubPlugin/Providers/DevHomeRepository.cs
+++ b/src/GithubPlugin/Providers/DevHomeRepository.cs
@@ -76,8 +76,9 @@ public class DevHomeRepository : Microsoft.Windows.DevHome.SDK.IRepository
                     var internalDeveloperId = DeveloperIdProvider.GetInstance().GetDeveloperIdInternal(developerId);
                     cloneOptions.CredentialsProvider = (url, user, cred) => new UsernamePasswordCredentials
                     {
-                        Username = internalDeveloperId.GetCredential().UserName,
-                        Password = internalDeveloperId.GetCredential().Password,
+                        // Password is a PAT unique to github.
+                        Username = internalDeveloperId.GetCredential().Password,
+                        Password = string.Empty,
                     };
                 }
 


### PR DESCRIPTION
Somewhere in ADO the support to clone private repos was removed.  Most likely by accident.

This PR is to re-add it.