### PR TITLE
Avoid unnecessary calls to Storage APIs

### DIFF
--- a/src/GithubPlugin/DataManager/GitHubDataManager.cs
+++ b/src/GithubPlugin/DataManager/GitHubDataManager.cs
@@ -25,7 +25,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
 
     public static IGitHubDataManager? CreateInstance(DataStoreOptions? options = null)
     {
-        options ??= DefaultOptions();
+        options ??= DefaultOptions;
 
         try
         {
@@ -640,7 +640,13 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
         }
     }
 
-    private static DataStoreOptions DefaultOptions()
+    // Making the default options a singleton to avoid repeatedly calling the storage APIs and
+    // creating a new GitHubDataStoreSchema when not necessary.
+    private static readonly Lazy<DataStoreOptions> LazyDataStoreOptions = new (DefaultOptionsInit);
+
+    private static DataStoreOptions DefaultOptions => LazyDataStoreOptions.Value;
+
+    private static DataStoreOptions DefaultOptionsInit()
     {
         return new DataStoreOptions
         {

--- a/src/GithubPlugin/Widgets/GithubWidget.cs
+++ b/src/GithubPlugin/Widgets/GithubWidget.cs
@@ -316,7 +316,7 @@ public abstract class GithubWidget : WidgetImpl
 
         try
         {
-            var path = Path.Combine(Windows.ApplicationModel.Package.Current.InstalledLocation.Path, GetTemplatePath(page));
+            var path = Path.Combine(AppContext.BaseDirectory, GetTemplatePath(page));
             var template = File.ReadAllText(path, Encoding.Default) ?? throw new FileNotFoundException(path);
             template = Resources.ReplaceIdentifers(template, Resources.GetWidgetResourceIdentifiers(), Log.Logger());
             Log.Logger()?.ReportDebug(Name, ShortId, $"Caching template for {page}");


### PR DESCRIPTION
- Replaced InstalledLocation with AppContext.BaseDirectory which is the equivalent.
- Made the DefaultOptions call a singleton as its result is only used in a read only manner and allows to make the storage API call only once but can't be made a true singleton due to TestOptions, so achieving it via the lazy pattern.