### PR TITLE
Changes on labels in Issues Widgets

### DIFF
--- a/src/GithubPlugin/Widgets/GithubIssuesWidget.cs
+++ b/src/GithubPlugin/Widgets/GithubIssuesWidget.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Text;
 using System.Text.Json.Nodes;
 using GitHubPlugin.Client;
 using GitHubPlugin.DataManager;
@@ -95,6 +96,7 @@ internal class GithubIssuesWidget : GithubWidget
 
             var issuesData = new JsonObject();
             var issuesArray = new JsonArray();
+
             foreach (var issueItem in issues)
             {
                 var issue = new JsonObject
@@ -109,6 +111,7 @@ internal class GithubIssuesWidget : GithubWidget
 
                 var labels = issueItem.Labels.ToList();
                 var issueLabels = new JsonArray();
+                StringBuilder labelsString = new ();
                 foreach (var label in labels)
                 {
                     var issueLabel = new JsonObject
@@ -118,9 +121,17 @@ internal class GithubIssuesWidget : GithubWidget
                     };
 
                     ((IList<JsonNode?>)issueLabels).Add(issueLabel);
+
+                    if (labelsString.Length != 0)
+                    {
+                        labelsString.Append("  ");
+                    }
+
+                    labelsString.Append(label.Name);
                 }
 
                 issue.Add("labels", issueLabels);
+                issue.Add("labelsString", labelsString.ToString());
 
                 ((IList<JsonNode?>)issuesArray).Add(issue);
             }

--- a/src/GithubPlugin/Widgets/Templates/GithubIssuesTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubIssuesTemplate.json
@@ -66,17 +66,12 @@
               "maxLines": 2
             },
             {
-              "type": "RichTextBlock",
+              "type": "TextBlock",
               "spacing": "None",
-              "inlines": [
-                {
-                  "$data": "${labels}",
-                  "type": "TextRun",
-                  "text": "${name}  ",
-                  "isSubtle": true,
-                  "size": "small"
-                }
-              ]
+              "weight": "lighter",
+              "size": "small",
+              "isSubtle": true,
+              "text": "${labelsString} "
             },
             {
               "type": "TextBlock",


### PR DESCRIPTION
Changing the labels from a RichTextBlock to a TextBlock. With this changes, the caret will not appear anymore and the labels will be clipped to maximum of one line.

<img width="461" alt="image" src="https://user-images.githubusercontent.com/13912953/232598849-60415999-7c94-4f81-a007-8b93161632e2.png">
