### PR TITLE
Adding loading container to issues and PR widgets

### DIFF
--- a/src/GithubPlugin/Helpers/Resources.cs
+++ b/src/GithubPlugin/Helpers/Resources.cs
@@ -54,6 +54,8 @@ public static class Resources
         return new string[]
         {
             "Widget_Template/ContentLoading",
+            "Widget_Template/EmptyIssues",
+            "Widget_Template/EmptyPulls",
             "Widget_Template/Pulls",
             "Widget_Template/Issues",
             "Widget_Template/Opened",

--- a/src/GithubPlugin/Strings/en-US/Resources.resw
+++ b/src/GithubPlugin/Strings/en-US/Resources.resw
@@ -281,4 +281,12 @@
     <value>Loading content...</value>
     <comment>Shown in Widget, when loading content (issues or PRs)</comment>
   </data>
+  <data name="Widget_Template.EmptyIssues" xml:space="preserve">
+    <value>There are no issues in this repository.</value>
+    <comment>Shown in Widget, when there are no issues</comment>
+  </data>
+  <data name="Widget_Template.EmptyPulls" xml:space="preserve">
+    <value>There are no pull requests in this repository.</value>
+    <comment>Shown in Widget, when there are no pull requests</comment>
+  </data>
 </root>

--- a/src/GithubPlugin/Widgets/GithubIssuesWidget.cs
+++ b/src/GithubPlugin/Widgets/GithubIssuesWidget.cs
@@ -127,10 +127,11 @@ internal class GithubIssuesWidget : GithubWidget
 
             issuesData.Add("issues", issuesArray);
             issuesData.Add("selected_repo", repository?.FullName ?? string.Empty);
+            issuesData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
 
             LastUpdated = DateTime.Now;
-            ContentData = issuesData.ToJsonString();
             DataState = WidgetDataState.Okay;
+            ContentData = issuesData.ToJsonString();
         }
         catch (Exception e)
         {

--- a/src/GithubPlugin/Widgets/GithubPullsWidget.cs
+++ b/src/GithubPlugin/Widgets/GithubPullsWidget.cs
@@ -112,10 +112,11 @@ internal class GithubPullsWidget : GithubWidget
 
             pullsData.Add("pulls", pullsArray);
             pullsData.Add("selected_repo", repository?.FullName ?? string.Empty);
+            pullsData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
 
             LastUpdated = DateTime.Now;
-            ContentData = pullsData.ToJsonString();
             DataState = WidgetDataState.Okay;
+            ContentData = pullsData.ToJsonString();
         }
         catch (Exception e)
         {

--- a/src/GithubPlugin/Widgets/Templates/GithubIssuesTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubIssuesTemplate.json
@@ -34,11 +34,11 @@
     },
     {
       "type": "Container",
-      "$when":  "${count(issues) == 0}",
+      "$when":  "${(count(issues) == 0)}",
       "items": [
         {
           "type": "TextBlock",
-          "text": "%Widget_Template/ContentLoading%",
+          "text": "${if(is_loading_data, '%Widget_Template/ContentLoading%', '%Widget_Template/EmptyIssues%')}",
           "wrap": true,
           "horizontalAlignment": "center"
         }

--- a/src/GithubPlugin/Widgets/Templates/GithubPullsTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubPullsTemplate.json
@@ -34,11 +34,11 @@
     },
     {
       "type": "Container",
-      "$when":  "${count(pulls) == 0}",
+      "$when":  "${(count(pulls) == 0)}",
       "items": [
         {
           "type": "TextBlock",
-          "text": "%Widget_Template/ContentLoading%",
+          "text": "${if(is_loading_data, '%Widget_Template/ContentLoading%', '%Widget_Template/EmptyPulls%')}",
           "wrap": true,
           "horizontalAlignment": "center"
         }


### PR DESCRIPTION
While the widgets are loading, there is no indicator to the user about that. This PR creates a small container with a simple loading message so the user will know that the widget is actually loading information.

<img width="229" alt="image" src="https://user-images.githubusercontent.com/13912953/233753235-7f3574db-20d0-4701-939e-06abd93b8fd3.png">

The message is shown while the number of issues/pulls is zero. So we will need other type of message for when the repository actually have zero issues/pulls.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/13912953/233756799-5db9e8ff-3552-49f8-b3c5-70374d3d8967.png">

If the content is empty after the data is loaded, we change the text of the container accordingly. 
