### PR TITLE
Change staleness check for notifications of failed PRs to 1 day.

### DIFF
--- a/src/GithubPlugin/DataManager/GitHubDataManager.cs
+++ b/src/GithubPlugin/DataManager/GitHubDataManager.cs
@@ -15,7 +15,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
     private static readonly string LastUpdatedKeyName = "LastUpdated";
     private static readonly TimeSpan NotificationRetentionTime = TimeSpan.FromDays(7);
     private static readonly TimeSpan SearchRetentionTime = TimeSpan.FromDays(7);
-    private static readonly TimeSpan PullRequestStaleTime = TimeSpan.FromDays(30);
+    private static readonly TimeSpan PullRequestStaleTime = TimeSpan.FromDays(1);
     private static readonly long CheckSuiteIdDependabot = 29110;
 
     private static readonly string Name = nameof(GitHubDataManager);


### PR DESCRIPTION
Bug feedback was that we were considering old failed pull requests notification worthy and posting notifications for them. The code already had this concept that we should not put notifications up for ancient and forgotten pull requests, so this change was very light and low-risk changing that staleness timespan from 30 days to 1 day as per feature owner request.

This value is comparing the "UpdatedAt" property of the pull request, not the created date, so if an old pull request were to be updated in the last day and then failed, then we would create a notification for that (which I believe is correct).
