### PR TITLE
Fixing assets not being copied to the build

### DIFF
--- a/src/GithubPlugin/GithubPlugin.csproj
+++ b/src/GithubPlugin/GithubPlugin.csproj
@@ -57,6 +57,10 @@
   </ItemGroup>
 
   <ItemGroup>
+	<Folder Include="Widgets\Assets\" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Update="Widgets\Assets\arrow.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fix line removed on last PR on icons that created the bug of assets not being copied when built. Tested with clean release build locally.