### PR TITLE
Fixing bug where widgets can be added when user enter invalid repo

### DIFF
--- a/src/GithubPlugin/Widgets/GithubWidget.cs
+++ b/src/GithubPlugin/Widgets/GithubWidget.cs
@@ -241,6 +241,8 @@ public abstract class GithubWidget : WidgetImpl
 
                 // TODO handle this and show something meaningful in the widget to indicate invalid input.
                 configurationData.Add("hasConfiguration", false);
+                configurationData.Add("configuring", true);
+
                 var repositoryData = new JsonObject
                 {
                     { "url", RepositoryUrl },


### PR DESCRIPTION
If the user inputs an invalid repository, there will be an error shown but the widget will be able to be pinned/added.

This PR fixes that, setting the flag that the widget is being configured to true.

<img width="283" alt="image" src="https://github.com/microsoft/devhomegithubextension/assets/13912953/4d4de955-b5ca-4c88-a5c5-9ca932f6d2f4">
