### PR TITLE
Update WinAppSDK to 1.3.230502000

### DIFF
--- a/src/GithubPlugin/GithubPlugin.csproj
+++ b/src/GithubPlugin/GithubPlugin.csproj
@@ -64,15 +64,15 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.0.123" />
-      <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-      <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-      <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
-      <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-      <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
-      <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.105" />
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
-      <PackageReference Include="Octokit" Version="5.0.4" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.105" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
+    <PackageReference Include="Octokit" Version="5.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GithubPluginServer/GithubPluginServer.csproj
+++ b/src/GithubPluginServer/GithubPluginServer.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/DevHome.Logging.csproj
+++ b/src/Logging/DevHome.Logging.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Telemetry/GITServices.Telemetry.csproj
+++ b/src/Telemetry/GITServices.Telemetry.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Console/GitHubPlugin.TestConsole.csproj
+++ b/test/Console/GitHubPlugin.TestConsole.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/GitHubPlugin/GitHubPlugin.Test.csproj
+++ b/test/GitHubPlugin/GitHubPlugin.Test.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.105" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Octokit" Version="5.0.4" />

--- a/test/UITest/GITServices.UITest.csproj
+++ b/test/UITest/GITServices.UITest.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Appium.WebDriver" Version="4.4.0" />


### PR DESCRIPTION
Needed to support Win10 and the DevHome specific WidgetService.

DevHome PR: https://github.com/microsoft/devhome/pull/417