### PR TITLE
Changing provider display name

### DIFF
--- a/src/GithubPlugin/Strings/en-US/Resources.resw
+++ b/src/GithubPlugin/Strings/en-US/Resources.resw
@@ -259,15 +259,15 @@
     <comment>Shown in Loading Widget, Message text</comment>
   </data>
   <data name="AppDisplayNameDev" xml:space="preserve">
-    <value>Dev Home GitHub Extension (Dev)</value>
+    <value>GitHub</value>
     <comment>The name of our application when built for dev ring</comment>
   </data>
   <data name="AppDisplayNameCanary" xml:space="preserve">
-    <value>Dev Home GitHub Extension (Canary)</value>
+    <value>GitHub</value>
     <comment>The name of our application when built for canary ring</comment>
   </data>
   <data name="AppDisplayNameStable" xml:space="preserve">
-    <value>Dev Home GitHub Extension (Preview)</value>
+    <value>GitHub</value>
     <comment>The name of our application when built for stable ring</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">

--- a/src/GithubPluginServer/Strings/en-us/Resources.resw
+++ b/src/GithubPluginServer/Strings/en-us/Resources.resw
@@ -59,15 +59,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDisplayNameDev" xml:space="preserve">
-    <value>Dev Home GitHub Extension (Dev)</value>
+    <value>GitHub</value>
     <comment>The name of our application when built for dev ring</comment>
   </data>
   <data name="AppDisplayNameCanary" xml:space="preserve">
-    <value>Dev Home GitHub Extension (Canary)</value>
+    <value>GitHub</value>
     <comment>The name of our application when built for canary ring</comment>
   </data>
   <data name="AppDisplayNameStable" xml:space="preserve">
-    <value>Dev Home GitHub Extension (Preview)</value>
+    <value>GitHub</value>
     <comment>The name of our application when built for stable ring</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">


### PR DESCRIPTION
Changing the display name of all releases to GitHub.

[Sister Dev HomePR](https://github.com/microsoft/devhomegithubextension/pull/79)

Please use the sister PR to see the change in action.