### PR TITLE
Update repo tool to use correct DisplayName

### DIFF
--- a/src/GithubPlugin/Providers/RepositoryProvider.cs
+++ b/src/GithubPlugin/Providers/RepositoryProvider.cs
@@ -17,13 +17,7 @@ public class RepositoryProvider : IRepositoryProvider
     {
     }
 
-#if CANARY_BUILD
-    public string DisplayName => Resources.GetResource(@"AppDisplayNameCanary");
-#elif STABLE_BUILD
-    public string DisplayName => Resources.GetResource(@"AppDisplayNameStable");
-#else
-    public string DisplayName => Resources.GetResource(@"AppDisplayNameDev");
-#endif
+    public string DisplayName => Resources.GetResource(@"RepositoryProviderDisplayName");
 
     /// <summary>
     /// Tries to parse the uri to check if it is a valid Github uri and if the current account can find it.

--- a/src/GithubPlugin/Strings/en-US/Resources.resw
+++ b/src/GithubPlugin/Strings/en-US/Resources.resw
@@ -256,15 +256,15 @@
     <comment>Shown in Loading Widget, Message text</comment>
   </data>
   <data name="AppDisplayNameDev" xml:space="preserve">
-    <value>GitHub</value>
+    <value>Dev Home GitHub Extension (Dev)</value>
     <comment>The name of our application when built for dev ring</comment>
   </data>
   <data name="AppDisplayNameCanary" xml:space="preserve">
-    <value>GitHub</value>
+    <value>Dev Home GitHub Extension (Canary)</value>
     <comment>The name of our application when built for canary ring</comment>
   </data>
   <data name="AppDisplayNameStable" xml:space="preserve">
-    <value>GitHub</value>
+    <value>Dev Home GitHub Extension (Preview)</value>
     <comment>The name of our application when built for stable ring</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
@@ -389,5 +389,9 @@
   <data name="Widget_Template/Updated" xml:space="preserve">
     <value>updated</value>
     <comment>Shown in widget</comment>
+  </data>
+  <data name="RepositoryProviderDisplayName" xml:space="preserve">
+    <value>GitHub</value>
+    <comment>Shown in various places, is GitHub even localized as a product name?</comment>
   </data>
 </root>

--- a/src/GithubPluginServer/Package.appxmanifest
+++ b/src/GithubPluginServer/Package.appxmanifest
@@ -1,12 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
-         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-         xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio"
-         xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
-         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
-         IgnorableNamespaces="uap uap3 rescap genTemplate">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
   <Identity Name="Microsoft.Windows.DevHomeGitHubExtension.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
     <DisplayName>Dev Home GitHub Extension (Dev)</DisplayName>
@@ -22,12 +15,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="DevHomeGitHubExtension.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameDev"
-                          Description="ms-resource:AppDescription"
-                          AppListEntry="none"
-                          BackgroundColor="transparent"
-                          Square150x150Logo="Assets\MedTile.png"
-                          Square44x44Logo="Assets\AppList.png">
+      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
         <uap:DefaultTile Wide310x150Logo="Assets\WideTile.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>

--- a/src/GithubPluginServer/Strings/en-us/Resources.resw
+++ b/src/GithubPluginServer/Strings/en-us/Resources.resw
@@ -59,15 +59,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDisplayNameDev" xml:space="preserve">
-    <value>GitHub</value>
+    <value>Dev Home GitHub Extension (Dev)</value>
     <comment>The name of our application when built for dev ring</comment>
   </data>
   <data name="AppDisplayNameCanary" xml:space="preserve">
-    <value>GitHub</value>
+    <value>Dev Home GitHub Extension (Canary)</value>
     <comment>The name of our application when built for canary ring</comment>
   </data>
   <data name="AppDisplayNameStable" xml:space="preserve">
-    <value>GitHub</value>
+    <value>Dev Home GitHub Extension (Preview)</value>
     <comment>The name of our application when built for stable ring</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">


### PR DESCRIPTION
Revert AppName to "Dev Home GitHub Extension (<build>)" but keep DisplayName() as "GitHub".  Developed with Darren.

Needs: https://github.com/microsoft/devhome/pull/464