### PR TITLE
Changing issue query to not use inner join

### DIFF
--- a/src/GithubPlugin/DataModel/DataObjects/Issue.cs
+++ b/src/GithubPlugin/DataModel/DataObjects/Issue.cs
@@ -304,7 +304,7 @@ public class Issue
         // updated, but ascending to get them in the order in which they were received in the search.
         // This is how we preserve whatever ordering the search had for these items without knowing
         // what that search ordering actually was.
-        var sql = @"SELECT * FROM Issue AS I INNER JOIN SearchIssue AS SI ON I.Id = SI.Issue WHERE SI.Search = @SearchId ORDER BY SI.TimeUpdated ASC";
+        var sql = @"SELECT * FROM Issue WHERE Id IN (SELECT Issue FROM SearchIssue WHERE Search = @SearchId ORDER BY TimeUpdated ASC)";
         var param = new
         {
             SearchId = search.Id,


### PR DESCRIPTION
## Summary of the pull request

This pull request fixes a bug (#141) on the Issues widget. See steps to repro in the issue page.

## References and relevant issues

## Detailed description of the pull request / Additional comments

What was happening is that a SQL query to get all the issues for an URL with a filter query had an inner join. This SQL query worked fine on the SQLite but the ORM was getting the Ids from the Query table instead of the Issues table, then, all the issues were with wrong Ids on the result of the query. So, the same SQL query was giving different results depending on where it was made.

Two avoid that, two possibilities were thought:
- Be explicit on what fields we wanted in our SQL query response, instead of using a '*' to get everything: this sound correct but it can be hard for maintenance in the future if the table or the objects had any change. 
- Avoid using Inner Join at all and using a different query: better for maintenance and for leveraging the fact that our tables and objects have matching names for their field.

The second approach was chosen at the moment for the reasons explained.

## Validation steps performed

## PR checklist
- [X] Closes #141 
- [x] Tests added/passed
- [ ] Documentation updated
