### PR TITLE
Enable special parser for localized resources

### DIFF
--- a/src/GithubPlugin/GithubPlugin.csproj
+++ b/src/GithubPlugin/GithubPlugin.csproj
@@ -67,6 +67,7 @@
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
       <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+      <PackageReference Include="MessageFormat" Version="6.0.2" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
       <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
       <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />

--- a/src/GithubPlugin/Helpers/TimeSpanHelper.cs
+++ b/src/GithubPlugin/Helpers/TimeSpanHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 using System.Text.Json.Nodes;
 using DevHome.Logging;
+using Jeffijoe.MessageFormat;
 
 namespace GitHubPlugin.Helpers;
 internal class TimeSpanHelper
@@ -13,42 +14,22 @@ internal class TimeSpanHelper
             return Resources.GetResource("WidgetTemplate_Now", log);
         }
 
-        if (timeSpan.TotalSeconds < 2)
-        {
-            return $"1 {Resources.GetResource("WidgetTemplate_SecondAgo", log)}";
-        }
-
         if (timeSpan.TotalMinutes < 1)
         {
-            return $"{timeSpan.Seconds} {Resources.GetResource("WidgetTemplate_SecondsAgo", log)}";
-        }
-
-        if (timeSpan.TotalMinutes < 2)
-        {
-            return $"1 {Resources.GetResource("WidgetTemplate_MinuteAgo", log)}";
+            return MessageFormatter.Format(Resources.GetResource("WidgetTemplate_SecondsAgo", log), new { seconds = timeSpan.Seconds });
         }
 
         if (timeSpan.TotalHours < 1)
         {
-            return $"{timeSpan.Minutes} {Resources.GetResource("WidgetTemplate_MinutesAgo", log)}";
-        }
-
-        if (timeSpan.TotalHours < 2)
-        {
-            return $"1 {Resources.GetResource("WidgetTemplate_HourAgo", log)}";
+            return MessageFormatter.Format(Resources.GetResource("WidgetTemplate_MinutesAgo", log), new { minutes = timeSpan.Minutes });
         }
 
         if (timeSpan.TotalDays < 1)
         {
-            return $"{timeSpan.Hours} {Resources.GetResource("WidgetTemplate_HourssAgo", log)}";
+            return MessageFormatter.Format(Resources.GetResource("WidgetTemplate_HoursAgo", log), new { hours = timeSpan.Hours });
         }
 
-        if (timeSpan.TotalDays < 2)
-        {
-            return $"1 {Resources.GetResource("WidgetTemplate_DayAgo", log)}";
-        }
-
-        return $"{timeSpan.Days} {Resources.GetResource("WidgetTemplate_DaysAgo", log)}";
+        return MessageFormatter.Format(Resources.GetResource("WidgetTemplate_DaysAgo", log), new { days = timeSpan.Days });
     }
 
     internal static string DateTimeOffsetToDisplayString(DateTimeOffset? dateTime, Logger? log)

--- a/src/GithubPlugin/Strings/en-US/Resources.resw
+++ b/src/GithubPlugin/Strings/en-US/Resources.resw
@@ -327,40 +327,24 @@
     <value>Items in widget will appear in chronological order from when the pull request or issue was last updated</value>
     <comment>Shown in Widget</comment>
   </data>
-  <data name="WidgetTemplate_DayAgo" xml:space="preserve">
-    <value>day ago</value>
-    <comment>Shown in Widget</comment>
-  </data>
   <data name="WidgetTemplate_DaysAgo" xml:space="preserve">
-    <value>days ago</value>
+    <value>{days, plural, =1 {# day ago} other {# days ago}}</value>
     <comment>Shown in Widget</comment>
   </data>
-  <data name="WidgetTemplate_HourAgo" xml:space="preserve">
-    <value>hour ago</value>
-    <comment>Shown in Widget</comment>
-  </data>
-  <data name="WidgetTemplate_HourssAgo" xml:space="preserve">
-    <value>hours ago</value>
-    <comment>Shown in Widget</comment>
-  </data>
-  <data name="WidgetTemplate_MinuteAgo" xml:space="preserve">
-    <value>minute ago</value>
+  <data name="WidgetTemplate_HoursAgo" xml:space="preserve">
+    <value>{hours, plural, =1 {# hour ago} other {# hours ago}}</value>
     <comment>Shown in Widget</comment>
   </data>
   <data name="WidgetTemplate_MinutesAgo" xml:space="preserve">
-    <value>minutes ago</value>
+    <value>{minutes, plural, =1 {# minute ago} other {# minutes ago}}</value>
+    <comment>Shown in Widget</comment>
+  </data>
+  <data name="WidgetTemplate_SecondsAgo" xml:space="preserve">
+    <value>{seconds, plural, =1 {# second ago} other {# seconds ago}}</value>
     <comment>Shown in Widget</comment>
   </data>
   <data name="WidgetTemplate_Now" xml:space="preserve">
     <value>now</value>
-    <comment>Shown in Widget</comment>
-  </data>
-  <data name="WidgetTemplate_SecondAgo" xml:space="preserve">
-    <value>second ago</value>
-    <comment>Shown in Widget</comment>
-  </data>
-  <data name="WidgetTemplate_SecondsAgo" xml:space="preserve">
-    <value>seconds ago</value>
     <comment>Shown in Widget</comment>
   </data>
   <data name="Widget_Template/ReviewRequestedFrom" xml:space="preserve">


### PR DESCRIPTION
## Summary of the pull request
When localizing singular vs plural, special parsing rules need to be applied per language.  This change adds support for that.
* This change can not be checked in until human translation has been enabled for this repo.  This is in progress.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
