### PR TITLE
Partner extension UX changes to align AddAccountDialog with design 

### DIFF
--- a/src/GithubPlugin/DeveloperId/LoginUIController.cs
+++ b/src/GithubPlugin/DeveloperId/LoginUIController.cs
@@ -107,7 +107,7 @@ internal class LoginUIController : IPluginAdaptiveCardController
                             ""type"": ""Image"",
                             ""style"": ""Person"",
                             ""url"": ""https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"",
-                            ""size"": ""Medium"",
+                            ""size"": ""small"",
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""None""
                         },

--- a/src/GithubPlugin/DeveloperId/LoginUIController.cs
+++ b/src/GithubPlugin/DeveloperId/LoginUIController.cs
@@ -123,7 +123,6 @@ internal class LoginUIController : IPluginAdaptiveCardController
                         {
                             ""type"": ""TextBlock"",
                             ""text"": """ + $"{loader.GetString("LoginUI_LoginPage_Subheading")}" + @""",
-                            ""isSubtle"": false,
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""None"",

--- a/src/GithubPlugin/DeveloperId/LoginUIController.cs
+++ b/src/GithubPlugin/DeveloperId/LoginUIController.cs
@@ -118,15 +118,16 @@ internal class LoginUIController : IPluginAdaptiveCardController
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""Small"",
-                            ""style"": ""heading""
+                            ""size"": ""large""
                         },
                         {
                             ""type"": ""TextBlock"",
                             ""text"": """ + $"{loader.GetString("LoginUI_LoginPage_Subheading")}" + @""",
-                            ""isSubtle"": true,
+                            ""isSubtle"": false,
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
-                            ""spacing"": ""None""
+                            ""spacing"": ""None"",
+                            ""size"": ""small""
                         },
                         {
                             ""type"": ""TextBlock"",

--- a/src/GithubPlugin/DeveloperId/LoginUIController.cs
+++ b/src/GithubPlugin/DeveloperId/LoginUIController.cs
@@ -169,8 +169,7 @@ internal class LoginUIController : IPluginAdaptiveCardController
                                             ""id"": ""Personal""
                                         }
                                     ],
-                                    ""horizontalAlignment"": ""Center"",
-                                    ""height"": ""stretch"",
+                                    ""horizontalAlignment"": ""Center""
                                     ""spacing"": ""None""
                                 }
                             ],
@@ -231,19 +230,16 @@ internal class LoginUIController : IPluginAdaptiveCardController
                                         }
                                     ],
                                     ""spacing"": ""None"",
-                                    ""horizontalAlignment"": ""Center"",
-                                    ""height"": ""stretch""
+                                    ""horizontalAlignment"": ""Center""
                                 }
                             ],
                             ""verticalContentAlignment"": ""Center"",
                             ""spacing"": ""None"",
-                            ""horizontalAlignment"": ""Center"",
-                            ""height"": ""stretch""
+                            ""horizontalAlignment"": ""Center""
                         }
                     ],
                     ""spacing"": ""None"",
                     ""horizontalAlignment"": ""Center"",
-                    ""height"": ""stretch"",
                     ""horizontalCellContentAlignment"": ""Center"",
                     ""verticalCellContentAlignment"": ""Center""
                 }
@@ -251,7 +247,6 @@ internal class LoginUIController : IPluginAdaptiveCardController
             ""firstRowAsHeaders"": false,
             ""spacing"": ""Medium"",
             ""horizontalAlignment"": ""Center"",
-            ""height"": ""stretch"",
             ""horizontalCellContentAlignment"": ""Center"",
             ""verticalCellContentAlignment"": ""Center"",
             ""showGridLines"": false

--- a/src/GithubPlugin/DeveloperId/LoginUIController.cs
+++ b/src/GithubPlugin/DeveloperId/LoginUIController.cs
@@ -169,7 +169,7 @@ internal class LoginUIController : IPluginAdaptiveCardController
                                             ""id"": ""Personal""
                                         }
                                     ],
-                                    ""horizontalAlignment"": ""Center""
+                                    ""horizontalAlignment"": ""Center"",
                                     ""spacing"": ""None""
                                 }
                             ],


### PR DESCRIPTION
## Summary of the pull request
This PR makes changes to the Add Account UI. 

## Detailed description of the pull request / Additional comments
To align with the figma design for AddAccountDialog, the below changes were made: 
- Modify size of content dialog
- Decrease github logo size 

This PR is in conjunction with https://github.com/microsoft/devhome/pull/1459

With the changes, the dialog now looks like the below: 
**Light Theme**
![image](https://github.com/microsoft/devhomegithubextension/assets/128866445/0ad2c6f8-91fd-4a22-836e-81f608a29cf7)


**Dark Theme**
![image](https://github.com/microsoft/devhomegithubextension/assets/128866445/cbcdc5f5-0022-4b68-b0a5-1f243dd52165)

## Validation steps performed
Manual Testing 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
