### PR TITLE
Fix spacing between issues

### DIFF
--- a/src/GithubPlugin/Widgets/Templates/GithubAssignedTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubAssignedTemplate.json
@@ -51,7 +51,7 @@
       "$data": "${items}",
       "type": "ColumnSet",
       "style": "emphasis",
-      "spacing": "small",
+      "spacing": "default",
       "selectAction": {
         "type": "Action.OpenUrl",
         "url": "${url}",

--- a/src/GithubPlugin/Widgets/Templates/GithubIssuesTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubIssuesTemplate.json
@@ -56,7 +56,7 @@
           "$data": "${issues}",
           "type": "ColumnSet",
           "style": "emphasis",
-          "spacing": "small",
+          "spacing": "default",
           "selectAction": {
             "type": "Action.OpenUrl",
             "url": "${url}",

--- a/src/GithubPlugin/Widgets/Templates/GithubMentionedInTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubMentionedInTemplate.json
@@ -51,7 +51,7 @@
       "$data": "${items}",
       "type": "ColumnSet",
       "style": "emphasis",
-      "spacing": "small",
+      "spacing": "default",
       "selectAction": {
         "type": "Action.OpenUrl",
         "url": "${url}",

--- a/src/GithubPlugin/Widgets/Templates/GithubPullsTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubPullsTemplate.json
@@ -56,7 +56,7 @@
           "$data": "${pulls}",
           "type": "ColumnSet",
           "style": "emphasis",
-          "spacing": "small",
+          "spacing": "default",
           "selectAction": {
             "type": "Action.OpenUrl",
             "url": "${url}",
@@ -87,7 +87,7 @@
                 },
                 {
                   "type": "ColumnSet",
-                  "spacing": "None",
+                  "spacing": "none",
                   "wrap": true,
                   "columns": [
                     {
@@ -111,7 +111,7 @@
                           "text": "${user}",
                           "isSubtle": true,
                           "size": "small",
-                          "spacing": "None",
+                          "spacing": "none",
                           "weight": "bolder"
                         }
                       ]

--- a/src/GithubPlugin/Widgets/Templates/GithubReviewTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubReviewTemplate.json
@@ -51,7 +51,7 @@
       "$data": "${items}",
       "type": "ColumnSet",
       "style": "emphasis",
-      "spacing": "small",
+      "spacing": "default",
       "selectAction": {
         "type": "Action.OpenUrl",
         "url": "${url}",


### PR DESCRIPTION
## Summary of the pull request
According to design specs, issue cards should have 8 px between them, which corresponds to "default" spacing. Update all widgets to match the spec.

![image](https://github.com/microsoft/devhomegithubextension/assets/47155823/9c8ee769-f3f3-48db-aa0f-4445ffceb136)


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
