### PR TITLE
Remove headers from widget configuration pages

### DIFF
--- a/src/GithubPlugin/GithubPlugin.csproj
+++ b/src/GithubPlugin/GithubPlugin.csproj
@@ -110,7 +110,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/GithubPlugin/Widgets/GithubAssignedWidget.cs
+++ b/src/GithubPlugin/Widgets/GithubAssignedWidget.cs
@@ -193,7 +193,7 @@ internal class GithubAssignedWidget : GithubWidget
                 },
                 UsePublicClientAsFallback = true,
             };
-            SearchIssuesRequest request = new SearchIssuesRequest()
+            var request = new SearchIssuesRequest()
             {
                 Assignee = AssignedToName,
             };
@@ -233,7 +233,7 @@ internal class GithubAssignedWidget : GithubWidget
 
             // Next step: composing the item list, which will be sent to the widget
             // the assignedIssues and assignedPulls contain the items, the final list of items
-            // should be orderd by creation time. Both lists are ordered so in every step
+            // should be ordered by creation time. Both lists are ordered so in every step
             // check the first items (if there are any) and compare them. Repeat until both
             // lists are empty.
             foreach (var item in items)
@@ -312,8 +312,11 @@ internal class GithubAssignedWidget : GithubWidget
 
     public string GetConfigurationData()
     {
-        var configurationData = new JsonObject();
-        configurationData.Add("showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory));
+        var configurationData = new JsonObject
+        {
+            { "showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory) },
+            { "configuring", true },
+        };
         return configurationData.ToJsonString();
     }
 

--- a/src/GithubPlugin/Widgets/GithubMentionedInWidget.cs
+++ b/src/GithubPlugin/Widgets/GithubMentionedInWidget.cs
@@ -174,7 +174,7 @@ internal class GithubMentionedInWidget : GithubWidget
                 UsePublicClientAsFallback = true,
             };
 
-            SearchIssuesRequest request = new SearchIssuesRequest()
+            var request = new SearchIssuesRequest()
             {
                 Mentions = MentionedName,
             };
@@ -288,8 +288,11 @@ internal class GithubMentionedInWidget : GithubWidget
 
     public string GetConfigurationData()
     {
-        var configurationData = new JsonObject();
-        configurationData.Add("showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory));
+        var configurationData = new JsonObject
+        {
+            { "showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory) },
+            { "configuring", true },
+        };
         return configurationData.ToJsonString();
     }
 

--- a/src/GithubPlugin/Widgets/Templates/GithubAssignedConfigurationTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubAssignedConfigurationTemplate.json
@@ -4,29 +4,6 @@
     "version": "1.5",
     "body": [
         {
-            "type": "Container",
-            "items": [
-                {
-                    "type": "TextBlock",
-                    "text": "%Widget_Template/AssignedTitle%",
-                    "wrap": true,
-                    "horizontalAlignment": "Center",
-                    "size": "Large",
-                    "weight": "Bolder"
-                },
-                {
-                    "type": "TextBlock",
-                    "text": "%Extension_Name/GitHub%",
-                    "wrap": true,
-                    "horizontalAlignment": "Center",
-                    "spacing": "None",
-                    "size": "Small",
-                    "isSubtle": true,
-                    "weight": "Lighter"
-                }
-            ]
-        },
-        {
             "type": "ColumnSet",
             "columns": [
                 {

--- a/src/GithubPlugin/Widgets/Templates/GithubIssuesConfigurationTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubIssuesConfigurationTemplate.json
@@ -4,29 +4,6 @@
   "version": "1.5",
   "body": [
     {
-      "type": "Container",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "%Widget_Template/Issues%",
-          "wrap": true,
-          "horizontalAlignment": "Center",
-          "size": "Large",
-          "weight": "Bolder"
-        },
-        {
-          "type": "TextBlock",
-          "text": "%Extension_Name/GitHub%",
-          "wrap": true,
-          "horizontalAlignment": "Center",
-          "spacing": "None",
-          "size": "Small",
-          "isSubtle": true,
-          "weight": "Lighter"
-        }
-      ]
-    },
-    {
       "type": "Input.Text",
       "id": "Repo",
       "label": "%Widget_Template_Label/Url%",

--- a/src/GithubPlugin/Widgets/Templates/GithubMentionedInConfigurationTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubMentionedInConfigurationTemplate.json
@@ -4,29 +4,6 @@
     "version": "1.5",
     "body": [
         {
-            "type": "Container",
-            "items": [
-                {
-                    "type": "TextBlock",
-                    "text": "%Widget_Template/Mentioned_user%",
-                    "wrap": true,
-                    "horizontalAlignment": "Center",
-                    "size": "Large",
-                    "weight": "Bolder"
-                },
-                {
-                    "type": "TextBlock",
-                    "text": "%Extension_Name/GitHub%",
-                    "wrap": true,
-                    "horizontalAlignment": "Center",
-                    "spacing": "None",
-                    "size": "Small",
-                    "isSubtle": true,
-                    "weight": "Lighter"
-                }
-            ]
-        },
-        {
             "type": "ColumnSet",
             "columns": [
                 {

--- a/src/GithubPlugin/Widgets/Templates/GithubPullsConfigurationTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubPullsConfigurationTemplate.json
@@ -4,29 +4,6 @@
   "version": "1.5",
   "body": [
     {
-      "type": "Container",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "%Widget_Template/PullRequests%",
-          "wrap": true,
-          "horizontalAlignment": "Center",
-          "size": "Large",
-          "weight": "Bolder"
-        },
-        {
-          "type": "TextBlock",
-          "text": "%Extension_Name/GitHub%",
-          "wrap": true,
-          "horizontalAlignment": "Center",
-          "spacing": "None",
-          "size": "Small",
-          "isSubtle": true,
-          "weight": "Lighter"
-        }
-      ]
-    },
-    {
       "type": "Input.Text",
       "id": "Repo",
       "label": "%Widget_Template_Label/Url%",

--- a/src/GithubPlugin/Widgets/Templates/GithubReviewConfigurationTemplate.json
+++ b/src/GithubPlugin/Widgets/Templates/GithubReviewConfigurationTemplate.json
@@ -3,28 +3,5 @@
     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
     "version": "1.5",
     "body": [
-        {
-            "type": "Container",
-            "items": [
-                {
-                    "type": "TextBlock",
-                    "text": "%Widget_Template/ReviewRequestedTitle%",
-                    "wrap": true,
-                    "horizontalAlignment": "Center",
-                    "size": "Large",
-                    "weight": "Bolder"
-                },
-                {
-                    "type": "TextBlock",
-                    "text": "%Extension_Name/GitHub%",
-                    "wrap": true,
-                    "horizontalAlignment": "Center",
-                    "spacing": "None",
-                    "size": "Small",
-                    "isSubtle": true,
-                    "weight": "Lighter"
-                }
-            ]
-        }
     ]
 }

--- a/src/GithubPluginServer/GithubPluginServer.csproj
+++ b/src/GithubPluginServer/GithubPluginServer.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Logging/DevHome.Logging.csproj
+++ b/src/Logging/DevHome.Logging.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Telemetry/GITServices.Telemetry.csproj
+++ b/src/Telemetry/GITServices.Telemetry.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Console/GitHubPlugin.TestConsole.csproj
+++ b/test/Console/GitHubPlugin.TestConsole.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/GitHubPlugin/GitHubPlugin.Test.csproj
+++ b/test/GitHubPlugin/GitHubPlugin.Test.csproj
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\..\src\GitHubPlugin\GitHubPlugin.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/UITest/GITServices.UITest.csproj
+++ b/test/UITest/GITServices.UITest.csproj
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\..\src\GitHubPlugin\GitHubPlugin.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary of the pull request
With https://github.com/microsoft/devhome/pull/1510, headers are now provided by Dev Home during configuration, so remove them from here.

Also, fix bug in Assigned To and Mentioned In widgets, which allowed pinning before they were configured.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Helps close https://github.com/microsoft/devhome/issues/1475
- [ ] Tests added/passed
- [ ] Documentation updated
