### PR TITLE
Fix GitHub string

### DIFF
--- a/src/GithubPlugin/DeveloperId/DeveloperIdProvider.cs
+++ b/src/GithubPlugin/DeveloperId/DeveloperIdProvider.cs
@@ -36,7 +36,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
 
     private readonly AuthenticationExperienceKind authenticationExperienceForGithubPlugin = AuthenticationExperienceKind.CardSession;
 
-    public string DisplayName => "Github";
+    public string DisplayName => "GitHub";
 
     // Private constructor for Singleton class.
     private DeveloperIdProvider()


### PR DESCRIPTION
## Summary of the pull request
Made the H in GitHub uppercase. I'm pretty sure this is the right place, but I wasn't able to successfully build on my machine to test. If someone could test this that would be great. :)

![MicrosoftTeams-image (20)](https://github.com/microsoft/devhomegithubextension/assets/48369326/9a226e22-7ec9-47b2-8d61-a0930f011d3a)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
