### PR TITLE
Removing build projects in parallel.

### DIFF
--- a/.github/workflows/GitHubExt-CI.yml
+++ b/.github/workflows/GitHubExt-CI.yml
@@ -56,11 +56,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore GITServices.sln -p:PublishReadyToRun=true
 
-    - name: Restore nuget packages
-      run: cmd /c "$env:VSDevCmd" "&" nuget restore GITServices.sln
-
     - name: Build_DevHomeGitHubExtension
-      run: cmd /c "$env:VSDevCmd" "&" msbuild /m /p:Configuration=${{ matrix.configuration }},Platform=${{ matrix.platform }} /restore GITServices.sln
+      run: cmd /c "$env:VSDevCmd" "&" msbuild /p:Configuration=${{ matrix.configuration }},Platform=${{ matrix.platform }} /restore GITServices.sln
 
     - name: Find vstest.console.exe
       if: ${{ matrix.platform != 'arm64' }}


### PR DESCRIPTION
## Summary of the pull request
According to [Microsoft learn](https://learn.microsoft.com/en-us/visualstudio/msbuild/writing-multi-processor-aware-loggers?view=vs-2022) loggers need to be multi-process build aware.  This isn't.  

Removing multi-project builds to prevent people from re-running their builds multiple times.

#219 is my attempt at figuring out what is going on.  Something, somewhere is not playing nice. Take a look here if you want to see the history.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
