### PR TITLE
Synchronize text writer in logger

### DIFF
--- a/src/Logging/listeners/LogFileListener.cs
+++ b/src/Logging/listeners/LogFileListener.cs
@@ -22,7 +22,7 @@ public class LogFileListener : ListenerBase, IDisposable
                 Mode = FileMode.Append,
                 Share = FileShare.ReadWrite,
             };
-            writer = new StreamWriter(filename, options);
+            writer = TextWriter.Synchronized(new StreamWriter(filename, options));
         }
         catch (IOException)
         {


### PR DESCRIPTION
## Summary of the pull request
Exception thrown when multiple threads attempt to write logs:
> Unhandled exception. System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
```
   at System.IO.StreamWriter.Write(String value)
   at DevHome.Logging.Listeners.LogFileListener.HandleLogFileEvent(LogEvent evt, Boolean newline, TimeSpan elapsed) in ...
```

Added `TextWriter.Synchronized` to creates a thread-safe wrapper around the StreamWriter.

Reference:
- https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.synchronized?view=net-7.0

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
