### PR TITLE
Public repo task was not using the request object.

### DIFF
--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -84,7 +84,7 @@ public class RepositoryProvider : IRepositoryProvider
 
                 // Gets only public repos for the owned repos.
                 request.Visibility = RepositoryRequestVisibility.Public;
-                var getPublicReposTask = client.Repository.GetAllForUser(developerId.LoginId, apiOptions);
+                var getPublicReposTask = client.Repository.GetAllForCurrent(request, apiOptions);
 
                 // this is getting private org and user repos.
                 request.Visibility = RepositoryRequestVisibility.Private;


### PR DESCRIPTION
## Summary of the pull request
Public repos was not using the request object because the method `GetForUser` did not accept the request object.

Changed to `GetForCurrent` so the request object can be used.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
