### PR TITLE
Add LastObserved to issues and pulls and remove unobserved data

### DIFF
--- a/src/GitHubExtension/DataManager/GitHubDataManager.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManager.cs
@@ -16,6 +16,13 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
     private static readonly TimeSpan NotificationRetentionTime = TimeSpan.FromDays(7);
     private static readonly TimeSpan SearchRetentionTime = TimeSpan.FromDays(7);
     private static readonly TimeSpan PullRequestStaleTime = TimeSpan.FromDays(1);
+
+    // It is possible different widgets have queries which touch the same pull requests.
+    // We want to keep this window large enough that we don't delete data being used by
+    // other clients which simply haven't been updated yet but will in the near future.
+    // This is a conservative time period to check for pruning and give time for other
+    // consumers using the data to update its freshness before we remove it.
+    private static readonly TimeSpan LastObservedDeleteSpan = TimeSpan.FromMinutes(15);
     private static readonly long CheckSuiteIdDependabot = 29110;
 
     private static readonly string Name = nameof(GitHubDataManager);
@@ -417,6 +424,10 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
 
                 Log.Logger()?.ReportDebug(Name, $"Updated developer pull requests for {repoFullName}.");
             }
+
+            // After we update for this developer, remove all pull requests for this developer that
+            // were not observed recently.
+            PullRequest.DeleteAllByDeveloperLoginAndLastObservedBefore(DataStore, devId.LoginId, DateTime.UtcNow - LastObservedDeleteSpan);
         }
     }
 
@@ -467,6 +478,9 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
 
             CreatePullRequestStatus(dsPullRequest);
         }
+
+        // Remove unobserved pull requests from this repository.
+        PullRequest.DeleteLastObservedBefore(DataStore, repository.Id, DateTime.UtcNow - LastObservedDeleteSpan);
     }
 
     private void CreatePullRequestStatus(PullRequest pullRequest)
@@ -602,6 +616,9 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
             // were not recently updated (within the last minute), remove them from the search result.
             SearchIssue.DeleteBefore(DataStore, search, DateTime.Now - TimeSpan.FromMinutes(1));
         }
+
+        // Remove issues from this repository that were not observed recently.
+        Issue.DeleteLastObservedBefore(DataStore, repository.Id, DateTime.UtcNow - LastObservedDeleteSpan);
     }
 
     // Removes unused data from the datastore.

--- a/src/GitHubExtension/DataManager/GitHubDataManager.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManager.cs
@@ -22,7 +22,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
     // other clients which simply haven't been updated yet but will in the near future.
     // This is a conservative time period to check for pruning and give time for other
     // consumers using the data to update its freshness before we remove it.
-    private static readonly TimeSpan LastObservedDeleteSpan = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan LastObservedDeleteSpan = TimeSpan.FromMinutes(6);
     private static readonly long CheckSuiteIdDependabot = 29110;
 
     private static readonly string Name = nameof(GitHubDataManager);

--- a/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
@@ -8,7 +8,7 @@ namespace GitHubExtension;
 public partial class GitHubDataManager
 {
     // This is how frequently the DataStore update occurs.
-    private static readonly TimeSpan UpdateInterval = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan UpdateInterval = TimeSpan.FromMinutes(5);
     private static DateTime lastUpdateTime = DateTime.MinValue;
 
     public static async Task Update()

--- a/src/GitHubExtension/DataModel/GitHubDataStoreSchema.cs
+++ b/src/GitHubExtension/DataModel/GitHubDataStoreSchema.cs
@@ -13,7 +13,7 @@ public class GitHubDataStoreSchema : IDataStoreSchema
     }
 
     // Update this anytime incompatible changes happen with a released version.
-    private const long SchemaVersionValue = 0x0004;
+    private const long SchemaVersionValue = 0x0005;
 
     private static readonly string Metadata =
     @"CREATE TABLE Metadata (" +
@@ -79,6 +79,7 @@ public class GitHubDataStoreSchema : IDataStoreSchema
         "TimeCreated INTEGER NOT NULL," +
         "TimeUpdated INTEGER NOT NULL," +
         "TimeClosed INTEGER NOT NULL," +
+        "TimeLastObserved INTEGER NOT NULL," +
         "HtmlUrl TEXT NULL COLLATE NOCASE," +
         "Locked INTEGER NOT NULL," +
         "AssigneeIds TEXT NULL COLLATE NOCASE," +
@@ -116,6 +117,7 @@ public class GitHubDataStoreSchema : IDataStoreSchema
         "TimeUpdated INTEGER NOT NULL," +
         "TimeMerged INTEGER NOT NULL," +
         "TimeClosed INTEGER NOT NULL," +
+        "TimeLastObserved INTEGER NOT NULL," +
         "HtmlUrl TEXT NULL COLLATE NOCASE," +
         "Locked INTEGER NOT NULL," +
         "Draft INTEGER NOT NULL," +


### PR DESCRIPTION
## Summary of the pull request
This fixes a data update issue where pull requests and issues were not being properly updated because the data request is only fetching "Open" pull requests and issues. So whenever a pull request or issue is changed from open to closed, it no longer shows up in the query, and so the cached data on that pull request is gone.

There were a few options considered to fix this:
1) Go through every pull request and issue we've seen and update its status.  That is a lot of extra rest calls, so that was not chosen.
2) Change the data request to include all pull requests and issues, so the closed ones would naturally be updated to the closed state.  That also was a rather significant change to the widget updating procedure and would be fetching a lot of useless uninteresting data and unnecessarily processing it. 
3) Add a timestamp to a data entry that is the "TimeLastObserved" for pull requests and issues. After updating, remove any data entries that were not recently observed. These were easy sql queries to add and efficient in purging any data entries that are no longer observed. This option has the added benefit of regularly pruning out the old issues and pull requests, which was some engineering work that has needed to happen for a while and hasn't, so this option was clearly the best one.
  
This fix implements option 3 in the above solutions, and any data that has not been observed within 6 minutes of an update occurring among a set of data will be deleted from the datastore on the next update.

## References and relevant issues
Closes #221 

## Detailed description of the pull request / Additional comments

This change involved the following:
* Update datastore schema for pull request and issue to add a new TimeLastObserved property.
* Update Issue and PullRequest data objects to use this new property, and to *always* set it every time the pull request or issue is updated.
* Add Deletion data object methods for clearing a repository of all unobserved data for a repository.
* For pull requests since we also update across repositories for all pull requests a developer has, we will also remove any pull requests from the developer that have not been observed recently.
* Added the delete calls to updating Issues, pull requests, and pull requests for developer after all of the data has been updated.
* Updated the developer pull request sync to be every 5 minutes instead of every 2. Two is very aggressive and setting to 5 makes it consistent with the Widget update rate.

It is important to note that data for pull requests and issues can be shared across multiple clients. For example, a developer pull request will get updated as part of any repository widgets where the pull requests exist, as well as the regular developer pull request check. Since this data is shared, we have to be careful in pruning "unobserved" data, because each update type is scoped. For developer PRs, it is scoped to the developer. For a repository issue list, it is scoped to the repository. The key observations here:

1) It is possible different consumers of a data entry update at different times. This is why there is a delay in the time between not observing something and deleting it - to provide opportunity for other consumers of that data to observe it before we removal so we don't remove data that is actively being used and observed by a query somewhere.

2) Data categories not being updated are not expected to have recently observed data. This is why we cannot do a blanket "delete if older than time foo" type solution. It must be scoped to the context of the repository or developer id which is being updated.

The time between removal can be tweaked, but I think about 6 minutes is a good starting point (Widgets update every 5 minutes). That should give time for all widgets to have a chance to update so we can remove with confidence. This means after an update, the removed entries might linger around for a few update cycles before they are removed. In practice we can probably be more aggressive, but I would rather roll this out with caution as data removal should not be something done recklessly.

## Validation steps performed
* I selfhosted the change monitoring pull requests in issues in a private repo and saw both prs and issues update on their own and be removed as they were closed.
* I verified the datastore was also pruned as part of this change and that only currently observed entries remained.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
