### PR TITLE
Corrected spelling (and casing) of error messages

### DIFF
--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -223,28 +223,28 @@ public class RepositoryProvider : IRepositoryProvider
             }
             catch (LibGit2Sharp.RecurseSubmodulesException recurseException)
             {
-                Providers.Log.Logger()?.ReportError("DevHomeRepository", "Could not clone all sub modules", recurseException);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, recurseException, "Could not clone all modules", recurseException.Message);
+                Providers.Log.Logger()?.ReportError("DevHomeRepository", "Could not clone all submodules.", recurseException);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, recurseException, "Could not clone all submodules.", recurseException.Message);
             }
             catch (LibGit2Sharp.UserCancelledException userCancelledException)
             {
-                Providers.Log.Logger()?.ReportError("DevHomeRepository", "The user stoped the clone operation", userCancelledException);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, userCancelledException, "User cancelled the operation", userCancelledException.Message);
+                Providers.Log.Logger()?.ReportError("DevHomeRepository", "The user stopped the clone operation.", userCancelledException);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, userCancelledException, "User cancelled the clone operation.", userCancelledException.Message);
             }
             catch (LibGit2Sharp.NameConflictException nameConflictException)
             {
                 Providers.Log.Logger()?.ReportError("DevHomeRepository", nameConflictException);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, nameConflictException, "The location exists and is non-empty", nameConflictException.Message);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, nameConflictException, "The destination location is non-empty.", nameConflictException.Message);
             }
             catch (LibGit2Sharp.LibGit2SharpException libGitTwoException)
             {
-                Providers.Log.Logger()?.ReportError("DevHomeRepository", $"Either no logged in account has access to this repo, or the repo can't be found", libGitTwoException);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LibGit2 threw an exception", "LibGit2 threw an exception");
+                Providers.Log.Logger()?.ReportError("DevHomeRepository", $"Either no logged in account has access to this repository, or the repository can't be found.", libGitTwoException);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LibGit2 library threw an exception.", "LibGit2 library threw an exception.");
             }
             catch (Exception e)
             {
-                Providers.Log.Logger()?.ReportError("DevHomeRepository", "Could not clone the repository", e);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repo", "Something happened when cloning the repo");
+                Providers.Log.Logger()?.ReportError("DevHomeRepository", "Could not clone the repository.", e);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repository.", "Something happened when cloning the repository.");
             }
 
             return new ProviderOperationResult(ProviderOperationStatus.Success, new ArgumentException("Nothing wrong"), "Nothing wrong", "Nothing wrong");

--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -229,7 +229,7 @@ public class RepositoryProvider : IRepositoryProvider
             catch (LibGit2Sharp.UserCancelledException userCancelledException)
             {
                 Providers.Log.Logger()?.ReportError("DevHomeRepository", "The user stoped the clone operation", userCancelledException);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, userCancelledException, "User cancalled the operation", userCancelledException.Message);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, userCancelledException, "User cancelled the operation", userCancelledException.Message);
             }
             catch (LibGit2Sharp.NameConflictException nameConflictException)
             {
@@ -239,12 +239,12 @@ public class RepositoryProvider : IRepositoryProvider
             catch (LibGit2Sharp.LibGit2SharpException libGitTwoException)
             {
                 Providers.Log.Logger()?.ReportError("DevHomeRepository", $"Either no logged in account has access to this repo, or the repo can't be found", libGitTwoException);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LigGit2 threw an exception", "LibGit2 Threw an exception");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LibGit2 threw an exception", "LibGit2 threw an exception");
             }
             catch (Exception e)
             {
                 Providers.Log.Logger()?.ReportError("DevHomeRepository", "Could not clone the repository", e);
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repo", "something happened when cloning the repo");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repo", "Something happened when cloning the repo");
             }
 
             return new ProviderOperationResult(ProviderOperationStatus.Success, new ArgumentException("Nothing wrong"), "Nothing wrong", "Nothing wrong");


### PR DESCRIPTION
## Summary of the pull request
Minor changes to exception messages, solving a typo and incorrect casing

## References and relevant issues
#258

## Detailed description of the pull request 

Maybe the Libgit2-exception should be rephrased entirely to be more helpful for end users, but that's beyond the aim of this small PR.

## Validation steps performed

## PR checklist
- [x] Closes #258