### PR TITLE
Enable widget customization

### DIFF
--- a/src/GitHubExtension/GitHubExtension.csproj
+++ b/src/GitHubExtension/GitHubExtension.csproj
@@ -80,7 +80,7 @@
       <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
       <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
       <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.254" />
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Octokit" Version="5.0.4" />
   </ItemGroup>

--- a/src/GitHubExtension/Helpers/Resources.cs
+++ b/src/GitHubExtension/Helpers/Resources.cs
@@ -96,6 +96,10 @@ public static class Resources
             "Widget_Template/PR_info",
             "Widget_Template/Updated",
             "Widget_Template/Query",
+            "Widget_Template_Button/Save",
+            "Widget_Template_Button/Cancel",
+            "Widget_Template_Tooltip/Save",
+            "Widget_Template_Tooltip/Cancel",
         };
     }
 }

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -400,4 +400,20 @@
   <data name="Settings_NotificationsDisabled" xml:space="preserve">
     <value>Notifications Disabled</value>
   </data>
+  <data name="Widget_Template_Button.Save" xml:space="preserve">
+    <value>Save</value>
+    <comment>Shown in Widget, Button text</comment>
+  </data>
+  <data name="Widget_Template_Button.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Shown in Widget, Button text</comment>
+  </data>
+  <data name="Widget_Template_Tooltip.Save" xml:space="preserve">
+    <value>Save</value>
+    <comment>Shown in Widget, Button tooltip</comment>
+  </data>
+  <data name="Widget_Template_Tooltip.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Shown in Widget, Button tooltip</comment>
+  </data>
 </root>

--- a/src/GitHubExtension/Widgets/Enums/WidgetAction.cs
+++ b/src/GitHubExtension/Widgets/Enums/WidgetAction.cs
@@ -18,4 +18,14 @@ public enum WidgetAction
     /// Action to initiate the user Sign-In.
     /// </summary>
     SignIn,
+
+    /// <summary>
+    /// Action to save after configuration.
+    /// </summary>
+    Save,
+
+    /// <summary>
+    /// Action to discard configuration changes and leave configuration flow.
+    /// </summary>
+    Cancel,
 }

--- a/src/GitHubExtension/Widgets/GitHubAssignedWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubAssignedWidget.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
+using GitHubExtension.Widgets.Enums;
 using Microsoft.Windows.Widgets.Providers;
 using Octokit;
 
@@ -70,6 +71,8 @@ internal class GitHubAssignedWidget : GitHubWidget
 
         set => SetState(EnumHelper.SearchCategoryToString(value));
     }
+
+    private SearchCategory? savedShowCategory;
 
     private string assignedToName = string.Empty;
 
@@ -178,6 +181,11 @@ internal class GitHubAssignedWidget : GitHubWidget
         if (DateTime.Now - LastUpdated < WidgetDataRequestMinTime)
         {
             Log.Logger()?.ReportDebug(Name, ShortId, "Data request too soon, skipping.");
+        }
+
+        if (ActivityState == WidgetActivityState.Configure)
+        {
+            return;
         }
 
         try
@@ -315,6 +323,7 @@ internal class GitHubAssignedWidget : GitHubWidget
         var configurationData = new JsonObject
         {
             { "showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory) },
+            { "savedShowCategory", savedShowCategory != null ? "savedShowCategory" : string.Empty },
             { "configuring", true },
         };
         return configurationData.ToJsonString();
@@ -329,6 +338,12 @@ internal class GitHubAssignedWidget : GitHubWidget
             LoadContentData(results);
             UpdateActivityState();
         }
+    }
+
+    public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)
+    {
+        savedShowCategory = ShowCategory;
+        SetConfigure();
     }
 }
 

--- a/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
@@ -213,6 +213,13 @@ internal class GitHubIssuesWidget : GitHubWidget
             if (fullName == e.Description && e.Context.Contains("Issues"))
             {
                 Log.Logger()?.ReportInfo(Name, ShortId, $"Received matching repository update event.");
+
+                // Don't update if we're in configuration mode.
+                if (ActivityState == WidgetActivityState.Configure)
+                {
+                    return;
+                }
+
                 LoadContentData();
                 UpdateActivityState();
             }

--- a/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
@@ -5,6 +5,8 @@ using System.Text.Json.Nodes;
 using GitHubExtension.Client;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
+using GitHubExtension.Widgets.Enums;
+using Microsoft.Windows.Widgets.Providers;
 using Octokit;
 
 namespace GitHubExtension.Widgets;
@@ -44,6 +46,11 @@ internal class GitHubIssuesWidget : GitHubWidget
         if (DateTime.Now - LastUpdated < WidgetDataRequestMinTime)
         {
             Log.Logger()?.ReportDebug(Name, ShortId, "Data request too soon, skipping.");
+        }
+
+        if (ActivityState == WidgetActivityState.Configure)
+        {
+            return;
         }
 
         try
@@ -210,5 +217,11 @@ internal class GitHubIssuesWidget : GitHubWidget
                 UpdateActivityState();
             }
         }
+    }
+
+    public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)
+    {
+        SavedRepositoryUrl = RepositoryUrl;
+        SetConfigure();
     }
 }

--- a/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
@@ -207,19 +207,19 @@ internal class GitHubIssuesWidget : GitHubWidget
     private void DataManagerUpdateHandler(object? source, DataManagerUpdateEventArgs e)
     {
         Log.Logger()?.ReportDebug(Name, ShortId, $"Data Update Event: Kind={e.Kind} Info={e.Description} Context={string.Join(",", e.Context)}");
+
+        // Don't update if we're in configuration mode.
+        if (ActivityState == WidgetActivityState.Configure)
+        {
+            return;
+        }
+
         if (e.Kind == DataManagerUpdateKind.Repository && !string.IsNullOrEmpty(RepositoryUrl))
         {
             var fullName = Validation.ParseFullNameFromGitHubURL(RepositoryUrl);
             if (fullName == e.Description && e.Context.Contains("Issues"))
             {
                 Log.Logger()?.ReportInfo(Name, ShortId, $"Received matching repository update event.");
-
-                // Don't update if we're in configuration mode.
-                if (ActivityState == WidgetActivityState.Configure)
-                {
-                    return;
-                }
-
                 LoadContentData();
                 UpdateActivityState();
             }

--- a/src/GitHubExtension/Widgets/GitHubMentionedInWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubMentionedInWidget.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
+using GitHubExtension.Widgets.Enums;
 using Microsoft.Windows.Widgets.Providers;
 using Octokit;
 
@@ -51,6 +52,8 @@ internal class GitHubMentionedInWidget : GitHubWidget
 
         set => SetState(EnumHelper.SearchCategoryToString(value));
     }
+
+    private SearchCategory? savedShowCategory;
 
     private string mentionedName = string.Empty;
 
@@ -158,6 +161,11 @@ internal class GitHubMentionedInWidget : GitHubWidget
         if (DateTime.Now - LastUpdated < WidgetDataRequestMinTime)
         {
             Log.Logger()?.ReportDebug(Name, ShortId, "Data request too soon, skipping.");
+        }
+
+        if (ActivityState == WidgetActivityState.Configure)
+        {
+            return;
         }
 
         try
@@ -291,6 +299,7 @@ internal class GitHubMentionedInWidget : GitHubWidget
         var configurationData = new JsonObject
         {
             { "showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory) },
+            { "savedShowCategory", savedShowCategory != null ? "savedShowCategory" : string.Empty },
             { "configuring", true },
         };
         return configurationData.ToJsonString();
@@ -305,6 +314,12 @@ internal class GitHubMentionedInWidget : GitHubWidget
             LoadContentData(results);
             UpdateActivityState();
         }
+    }
+
+    public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)
+    {
+        savedShowCategory = ShowCategory;
+        SetConfigure();
     }
 }
 

--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -5,6 +5,8 @@ using System.Text.Json.Nodes;
 using GitHubExtension.Client;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
+using GitHubExtension.Widgets.Enums;
+using Microsoft.Windows.Widgets.Providers;
 using Octokit;
 
 namespace GitHubExtension.Widgets;
@@ -46,6 +48,11 @@ internal class GitHubPullsWidget : GitHubWidget
         if (DateTime.Now - LastUpdated < WidgetDataRequestMinTime)
         {
             Log.Logger()?.ReportDebug(Name, ShortId, "Data request too soon, skipping.");
+        }
+
+        if (ActivityState == WidgetActivityState.Configure)
+        {
+            return;
         }
 
         try
@@ -183,5 +190,11 @@ internal class GitHubPullsWidget : GitHubWidget
                 UpdateActivityState();
             }
         }
+    }
+
+    public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)
+    {
+        SavedRepositoryUrl = RepositoryUrl;
+        SetConfigure();
     }
 }

--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -186,6 +186,13 @@ internal class GitHubPullsWidget : GitHubWidget
             if (fullName == e.Description && e.Context.Contains("PullRequests"))
             {
                 Log.Logger()?.ReportInfo(Name, ShortId, $"Received matching repository update event.");
+
+                // Don't update if we're in configuration mode.
+                if (ActivityState == WidgetActivityState.Configure)
+                {
+                    return;
+                }
+
                 LoadContentData();
                 UpdateActivityState();
             }

--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -180,19 +180,19 @@ internal class GitHubPullsWidget : GitHubWidget
     private void DataManagerUpdateHandler(object? source, DataManagerUpdateEventArgs e)
     {
         Log.Logger()?.ReportDebug(Name, ShortId, $"Data Update Event: Kind={e.Kind} Info={e.Description} Context={string.Join(",", e.Context)}");
+
+        // Don't update if we're in configuration mode.
+        if (ActivityState == WidgetActivityState.Configure)
+        {
+            return;
+        }
+
         if (e.Kind == DataManagerUpdateKind.Repository && !string.IsNullOrEmpty(RepositoryUrl))
         {
             var fullName = Validation.ParseFullNameFromGitHubURL(RepositoryUrl);
             if (fullName == e.Description && e.Context.Contains("PullRequests"))
             {
                 Log.Logger()?.ReportInfo(Name, ShortId, $"Received matching repository update event.");
-
-                // Don't update if we're in configuration mode.
-                if (ActivityState == WidgetActivityState.Configure)
-                {
-                    return;
-                }
-
                 LoadContentData();
                 UpdateActivityState();
             }

--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
+using GitHubExtension.Widgets.Enums;
 using Microsoft.Windows.Widgets.Providers;
 using Octokit;
 
@@ -107,6 +108,11 @@ internal class GitHubReviewWidget : GitHubWidget
         if (DateTime.Now - LastUpdated < WidgetDataRequestMinTime)
         {
             Log.Logger()?.ReportDebug(Name, ShortId, "Data request too soon, skipping.");
+        }
+
+        if (ActivityState == WidgetActivityState.Configure)
+        {
+            return;
         }
 
         try

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -44,6 +44,8 @@ public abstract class GitHubWidget : WidgetImpl
         set => SetState(value);
     }
 
+    protected string SavedRepositoryUrl { get; set; } = string.Empty;
+
     protected DateTime LastUpdated { get; set; } = DateTime.MinValue;
 
     protected DataUpdater DataUpdater { get; set; }
@@ -137,6 +139,16 @@ public abstract class GitHubWidget : WidgetImpl
                 _ = HandleSignIn();
                 break;
 
+            case WidgetAction.Save:
+                SavedRepositoryUrl = string.Empty;
+                SetActive();
+                break;
+
+            case WidgetAction.Cancel:
+                RepositoryUrl = SavedRepositoryUrl;
+                SetActive();
+                break;
+
             case WidgetAction.Unknown:
                 Log.Logger()?.ReportError(Name, ShortId, $"Unknown verb: {actionInvokedArgs.Verb}");
                 break;
@@ -209,6 +221,7 @@ public abstract class GitHubWidget : WidgetImpl
             };
 
             configurationData.Add("configuration", repositoryData);
+            configurationData.Add("savedRepositoryUrl", SavedRepositoryUrl);
 
             return configurationData.ToString();
         }
@@ -244,6 +257,7 @@ public abstract class GitHubWidget : WidgetImpl
 
                 configurationData.Add("hasConfiguration", true);
                 configurationData.Add("configuration", repositoryData);
+                configurationData.Add("savedRepositoryUrl", SavedRepositoryUrl);
             }
             catch (Exception ex)
             {
@@ -435,6 +449,11 @@ public abstract class GitHubWidget : WidgetImpl
         // Only update per the update interval.
         // This is intended to be dynamic in the future.
         if (DateTime.Now - lastUpdateRequest < WidgetRefreshRate)
+        {
+            return;
+        }
+
+        if (ActivityState == WidgetActivityState.Configure)
         {
             return;
         }

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -222,6 +222,7 @@ public abstract class GitHubWidget : WidgetImpl
 
             configurationData.Add("configuration", repositoryData);
             configurationData.Add("savedRepositoryUrl", SavedRepositoryUrl);
+            configurationData.Add("saveEnabled", false);
 
             return configurationData.ToString();
         }
@@ -258,6 +259,7 @@ public abstract class GitHubWidget : WidgetImpl
                 configurationData.Add("hasConfiguration", true);
                 configurationData.Add("configuration", repositoryData);
                 configurationData.Add("savedRepositoryUrl", SavedRepositoryUrl);
+                configurationData.Add("saveEnabled", SavedRepositoryUrl != data);
             }
             catch (Exception ex)
             {
@@ -272,6 +274,7 @@ public abstract class GitHubWidget : WidgetImpl
 
                 configurationData.Add("errorMessage", ex.Message);
                 configurationData.Add("configuration", repositoryData);
+                configurationData.Add("saveEnabled", false);
 
                 return configurationData.ToString();
             }

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -143,6 +143,8 @@ public abstract class GitHubWidget : WidgetImpl
         }
     }
 
+    public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs) => throw new NotImplementedException();
+
     private void HandleCheckUrl(WidgetActionInvokedArgs args)
     {
         // Set loading page while we fetch data from GitHub.

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
@@ -111,6 +111,50 @@
       "$when": "${$root.hasConfiguration}",
       "horizontalAlignment": "Left",
       "bleed": true
+    },
+    {
+      "type": "ColumnSet",
+      "spacing": "Medium",
+      "$when": "${$root.savedRepositoryUrl != \"\"}",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Container",
+              "items": [
+                {
+                  "type": "ActionSet",
+                  "actions": [
+                    {
+                      "type": "Action.Execute",
+                      "title": "%Widget_Template_Button/Save%",
+                      "verb": "Save",
+                      "tooltip": "%Widget_Template_Tooltip/Save%",
+                      "isEnabled": "${$root.hasConfiguration}"
+                    },
+                    {
+                      "type": "Action.Execute",
+                      "title": "%Widget_Template_Button/Cancel%",
+                      "verb": "Cancel",
+                      "tooltip": "%Widget_Template_Tooltip/Cancel%"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch"
+        }
+      ]
     }
   ]
 }

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
@@ -136,7 +136,7 @@
                       "title": "%Widget_Template_Button/Save%",
                       "verb": "Save",
                       "tooltip": "%Widget_Template_Tooltip/Save%",
-                      "isEnabled": "${$root.hasConfiguration}"
+                      "isEnabled": "${$root.saveEnabled}"
                     },
                     {
                       "type": "Action.Execute",

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -96,6 +96,50 @@
       "$when": "${$root.hasConfiguration}",
       "horizontalAlignment": "Left",
       "bleed": true
+    },
+    {
+      "type": "ColumnSet",
+      "spacing": "Medium",
+      "$when": "${$root.savedRepositoryUrl != \"\"}",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Container",
+              "items": [
+                {
+                  "type": "ActionSet",
+                  "actions": [
+                    {
+                      "type": "Action.Execute",
+                      "title": "%Widget_Template_Button/Save%",
+                      "verb": "Save",
+                      "tooltip": "%Widget_Template_Tooltip/Save%",
+                      "isEnabled": "${$root.hasConfiguration}"
+                    },
+                    {
+                      "type": "Action.Execute",
+                      "title": "%Widget_Template_Button/Cancel%",
+                      "verb": "Cancel",
+                      "tooltip": "%Widget_Template_Tooltip/Cancel%"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch"
+        }
+      ]
     }
   ]
 }

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -121,7 +121,7 @@
                       "title": "%Widget_Template_Button/Save%",
                       "verb": "Save",
                       "tooltip": "%Widget_Template_Tooltip/Save%",
-                      "isEnabled": "${$root.hasConfiguration}"
+                      "isEnabled": "${saveEnabled}"
                     },
                     {
                       "type": "Action.Execute",

--- a/src/GitHubExtension/Widgets/WidgetImpl.cs
+++ b/src/GitHubExtension/Widgets/WidgetImpl.cs
@@ -46,5 +46,7 @@ public abstract class WidgetImpl
 
     public abstract void OnActionInvoked(WidgetActionInvokedArgs actionInvokedArgs);
 
+    public abstract void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs);
+
     public abstract void OnWidgetContextChanged(WidgetContextChangedArgs contextChangedArgs);
 }

--- a/src/GitHubExtension/Widgets/WidgetProvider.cs
+++ b/src/GitHubExtension/Widgets/WidgetProvider.cs
@@ -9,7 +9,7 @@ namespace GitHubExtension.Widgets;
 [ComVisible(true)]
 [ClassInterface(ClassInterfaceType.None)]
 [Guid("F23870B0-B391-4466-84E2-42A991078613")]
-public sealed class WidgetProvider : IWidgetProvider
+public sealed class WidgetProvider : IWidgetProvider, IWidgetProvider2
 {
     public WidgetProvider()
     {
@@ -137,6 +137,17 @@ public sealed class WidgetProvider : IWidgetProvider
         if (runningWidgets.ContainsKey(widgetId))
         {
             runningWidgets[widgetId].OnActionInvoked(actionInvokedArgs);
+        }
+    }
+
+    public void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)
+    {
+        Log.Logger()?.ReportDebug($"OnCustomizationRequested id: {customizationRequestedArgs.WidgetContext.Id} definitionId: {customizationRequestedArgs.WidgetContext.DefinitionId}");
+        var widgetContext = customizationRequestedArgs.WidgetContext;
+        var widgetId = widgetContext.Id;
+        if (runningWidgets.ContainsKey(widgetId))
+        {
+            runningWidgets[widgetId].OnCustomizationRequested(customizationRequestedArgs);
         }
     }
 

--- a/src/GitHubExtensionServer/GitHubExtensionServer.csproj
+++ b/src/GitHubExtensionServer/GitHubExtensionServer.csproj
@@ -47,7 +47,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GitHubExtensionServer/Package.appxmanifest
+++ b/src/GitHubExtensionServer/Package.appxmanifest
@@ -1,5 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
+  <Extensions>
+    <Extension Category="windows.activatableClass.proxyStub">
+      <ProxyStub ClassId="00000355-0000-0000-C000-000000000046">
+        <Path>Microsoft.Windows.Widgets.winmd</Path>
+        <Interface Name="Microsoft.Windows.Widgets.Providers.IWidgetProvider" InterfaceId="5C5774CC-72A0-452D-B9ED-075C0DD25EED" />
+        <Interface Name="Microsoft.Windows.Widgets.Providers.IWidgetProvider2" InterfaceId="38C3A963-DD93-479D-9276-04BF84EE1816" />
+      </ProxyStub>
+    </Extension>
+  </Extensions>
   <Identity Name="Microsoft.Windows.DevHomeGitHubExtension.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
     <DisplayName>Dev Home GitHub Extension (Dev)</DisplayName>
@@ -212,7 +221,7 @@
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Reviews" DisplayName="Review requested" Description="List of pull requests where the user is requested for a review.">
+                  <Definition Id="GitHub_Reviews" DisplayName="Review requested" Description="List of pull requests where the user is requested for a review." IsCustomizable="false">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />

--- a/src/GitHubExtensionServer/Package.appxmanifest
+++ b/src/GitHubExtensionServer/Package.appxmanifest
@@ -85,7 +85,7 @@
                   <CreateInstance ClassId="F23870B0-B391-4466-84E2-42A991078613" />
                 </Activation>
                 <Definitions>
-                  <Definition Id="GitHub_Issues" DisplayName="Issues" Description="List of issues in a GitHub repository.">
+                  <Definition Id="GitHub_Issues" DisplayName="Issues" Description="List of issues in a GitHub repository." IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -119,7 +119,7 @@
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_PullRequests" DisplayName="Pull requests" Description="List of open pull requests in a GitHub repository.">
+                  <Definition Id="GitHub_PullRequests" DisplayName="Pull requests" Description="List of open pull requests in a GitHub repository." IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -153,7 +153,7 @@
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_MentionedIns" DisplayName="Mentioned me" Description="List of issues and pull requests the user is mentioned in in a GitHub repository.">
+                  <Definition Id="GitHub_MentionedIns" DisplayName="Mentioned me" Description="List of issues and pull requests the user is mentioned in in a GitHub repository." IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -187,7 +187,7 @@
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Assigneds" DisplayName="Assigned to me" Description="List of pull requests and issues assigned to the user in a GitHub repository.">
+                  <Definition Id="GitHub_Assigneds" DisplayName="Assigned to me" Description="List of pull requests and issues assigned to the user in a GitHub repository." IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />

--- a/src/Logging/DevHome.Logging.csproj
+++ b/src/Logging/DevHome.Logging.csproj
@@ -17,7 +17,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Telemetry/GitHubExtension.Telemetry.csproj
+++ b/src/Telemetry/GitHubExtension.Telemetry.csproj
@@ -16,7 +16,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Console/GitHubExtension.TestConsole.csproj
+++ b/test/Console/GitHubExtension.TestConsole.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/GitHubExtension/GitHubExtension.Test.csproj
+++ b/test/GitHubExtension/GitHubExtension.Test.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.254" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Octokit" Version="5.0.4" />

--- a/test/UITest/GitHubExtension.UITest.csproj
+++ b/test/UITest/GitHubExtension.UITest.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Appium.WebDriver" Version="4.4.0" />


### PR DESCRIPTION
## Summary of the pull request
Implement customization enabled by https://github.com/microsoft/devhome/pull/1819

When the user selects "Customize" in the widget menu, the widget will switch to its customization flow. From there, they can edit the data they put in during the "add" flow and save, or cancel and revert everything back to the way the widget was before.

By implementing the IWidgetProvider2 interface provided by WinAppSDK 1.4, the widget can opt into receiving notifications when the user selects the "Customize" menu, and provide this experience. Otherwise, customization menu item is not available.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
