### PR TITLE
After editing widget, show loading page instead of stale data

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubAssignedWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubAssignedWidget.cs
@@ -126,6 +126,10 @@ internal class GitHubAssignedWidget : GitHubWidget
             if (dataObject != null && dataObject.ShowCategory != null)
             {
                 ShowCategory = EnumHelper.StringToSearchCategory(dataObject.ShowCategory);
+
+                // If we got here during the customization flow, we need to LoadContentData again
+                // so we can show the loading page rather than stale data.
+                LoadContentData();
                 UpdateActivityState();
             }
         }

--- a/src/GitHubExtension/Widgets/GitHubMentionedInWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubMentionedInWidget.cs
@@ -146,6 +146,10 @@ internal class GitHubMentionedInWidget : GitHubWidget
             if (dataObject != null && dataObject.ShowCategory != null)
             {
                 ShowCategory = EnumHelper.StringToSearchCategory(dataObject.ShowCategory);
+
+                // If we got here during the customization flow, we need to LoadContentData again
+                // so we can show the loading page rather than stale data.
+                LoadContentData();
                 UpdateActivityState();
             }
         }

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -150,6 +150,11 @@ public abstract class GitHubWidget : WidgetImpl
 
                 SavedRepositoryUrl = string.Empty;
                 LoadContentData();
+
+                // Reset the throttle time and force an immediate data update request.
+                LastUpdated = DateTime.MinValue;
+                RequestContentData();
+
                 SetActive();
                 break;
 

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -140,7 +140,16 @@ public abstract class GitHubWidget : WidgetImpl
                 break;
 
             case WidgetAction.Save:
+                // Set loading page while we swap out the data.
+                Page = WidgetPageState.Loading;
+
+                // It might take some time to get the new data, so
+                // set data state to "unknown" so that loading page is shown.
+                DataState = WidgetDataState.Unknown;
+                UpdateWidget();
+
                 SavedRepositoryUrl = string.Empty;
+                LoadContentData();
                 SetActive();
                 break;
 


### PR DESCRIPTION
## Summary of the pull request
Widgets want to show stale data after customization, until they can load the new data and switch to that. We should show the loading page instead.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
