### PR TITLE
Change PullRequest time and label to match sort order.

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -112,7 +112,7 @@ internal class GitHubPullsWidget : GitHubWidget
                     { "title", pullItem.Title },
                     { "url", pullItem.HtmlUrl },
                     { "number", pullItem.Number },
-                    { "date", TimeSpanHelper.DateTimeOffsetToDisplayString(pullItem.CreatedAt, Log.Logger()) },
+                    { "date", TimeSpanHelper.DateTimeOffsetToDisplayString(pullItem.UpdatedAt, Log.Logger()) },
                     { "user", pullItem.Author.Login },
                     { "avatar", pullItem.Author.AvatarUrl },
                     { "icon", pullsIconData },

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsTemplate.json
@@ -121,7 +121,7 @@
                 {
                   "type": "TextBlock",
                   "size": "small",
-                  "text": "#${number} %Widget_Template/Opened% ${date}",
+                  "text": "#${number} %Widget_Template/Updated% ${date}",
                   "isSubtle": true,
                   "spacing": "small",
                   "wrap": true


### PR DESCRIPTION
## Summary of the pull request
Pull requests are sorted by TimeUpdated (most recent is first), but the label shows TimeCreated, which can be confusing. This fixes them so they show TimeUpdated in the Widget text and the date is the time updated, not the time created. This makes the pull request time and label match the sort order.

![prupdated](https://github.com/microsoft/devhomegithubextension/assets/18407763/ce0886cb-653c-4617-aa6c-38702df8ef15)


## References and relevant issues

## Detailed description of the pull request / Additional comments
Changed pull request display time from CreatedAt to UpdatedAt and associated label.

## Validation steps performed
Verified the change (see above image).

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
