### PR TITLE
Add GitHub Enterprise Server support

### DIFF
--- a/src/GitHubExtension/Client/GithubClientProvider.cs
+++ b/src/GitHubExtension/Client/GithubClientProvider.cs
@@ -83,8 +83,15 @@ public class GitHubClientProvider
 
         if (logRateLimit)
         {
-            var miscRateLimit = await client.RateLimit.GetRateLimits();
-            Log.Logger()?.ReportInfo($"Rate Limit:  Remaining: {miscRateLimit.Resources.Core.Remaining}  Total: {miscRateLimit.Resources.Core.Limit}  Resets: {miscRateLimit.Resources.Core.Reset.ToStringInvariant()}");
+            try
+            {
+                var miscRateLimit = await client.RateLimit.GetRateLimits();
+                Log.Logger()?.ReportInfo($"Rate Limit:  Remaining: {miscRateLimit.Resources.Core.Remaining}  Total: {miscRateLimit.Resources.Core.Limit}  Resets: {miscRateLimit.Resources.Core.Reset.ToStringInvariant()}");
+            }
+            catch (Exception ex)
+            {
+                Log.Logger()?.ReportInfo($"Rate limiting not enabled for server: {ex.Message}");
+            }
         }
 
         return client;

--- a/src/GitHubExtension/Client/GithubClientProvider.cs
+++ b/src/GitHubExtension/Client/GithubClientProvider.cs
@@ -90,7 +90,7 @@ public class GitHubClientProvider
             }
             catch (Exception ex)
             {
-                Log.Logger()?.ReportInfo($"Rate limiting not enabled for server: {ex.Message}");
+                Log.Logger()?.ReportError($"Rate limiting not enabled for server.", ex);
             }
         }
 

--- a/src/GitHubExtension/Client/Validation.cs
+++ b/src/GitHubExtension/Client/Validation.cs
@@ -223,6 +223,7 @@ public static class Validation
     {
         if (new EnterpriseProbe(new ProductHeaderValue(Constants.DEV_HOME_APPLICATION_NAME)).Probe(server).Result != EnterpriseProbeResult.Ok)
         {
+            Log.Logger()?.ReportError($"EnterpriseServer {server.AbsoluteUri} is not reachable");
             return false;
         }
 

--- a/src/GitHubExtension/Client/Validation.cs
+++ b/src/GitHubExtension/Client/Validation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 using GitHubExtension.DataModel;
+using Octokit;
 
 namespace GitHubExtension.Client;
 
@@ -216,5 +217,15 @@ public static class Validation
         }
 
         return n;
+    }
+
+    public static bool IsReachableGitHubEnterpriseServerURL(Uri server)
+    {
+        if (new EnterpriseProbe(new ProductHeaderValue(Constants.DEV_HOME_APPLICATION_NAME)).Probe(server).Result != EnterpriseProbeResult.Ok)
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/GitHubExtension/Client/Validation.cs
+++ b/src/GitHubExtension/Client/Validation.cs
@@ -219,11 +219,20 @@ public static class Validation
         return n;
     }
 
-    public static bool IsReachableGitHubEnterpriseServerURL(Uri server)
+    public static async Task<bool> IsReachableGitHubEnterpriseServerURL(Uri server)
     {
-        if (new EnterpriseProbe(new ProductHeaderValue(Constants.DEV_HOME_APPLICATION_NAME)).Probe(server).Result != EnterpriseProbeResult.Ok)
+        try
         {
-            Log.Logger()?.ReportError($"EnterpriseServer {server.AbsoluteUri} is not reachable");
+            var probeResult = await new EnterpriseProbe(new ProductHeaderValue(Constants.DEV_HOME_APPLICATION_NAME)).Probe(server);
+            if (probeResult != EnterpriseProbeResult.Ok)
+            {
+                Log.Logger()?.ReportError($"EnterpriseServer {server.AbsoluteUri} is not reachable");
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Logger()?.ReportError($"EnterpriseServer {server.AbsoluteUri} could not be probed.", ex);
             return false;
         }
 

--- a/src/GitHubExtension/Constants.cs
+++ b/src/GitHubExtension/Constants.cs
@@ -6,5 +6,6 @@ internal class Constants
 {
 #pragma warning disable SA1310 // Field names should not contain underscore
     public const string DEV_HOME_APPLICATION_NAME = "DevHome";
+    public const string GITHUB_COM_URL = "https://api.github.com/";
 #pragma warning restore SA1310 // Field names should not contain underscore
 }

--- a/src/GitHubExtension/DataManager/GitHubSearchManger.cs
+++ b/src/GitHubExtension/DataManager/GitHubSearchManger.cs
@@ -4,6 +4,7 @@
 using GitHubExtension.Client;
 using GitHubExtension.DataManager;
 using GitHubExtension.DataModel;
+using Microsoft.Windows.DevHome.SDK;
 
 namespace GitHubExtension;
 
@@ -30,6 +31,41 @@ public partial class GitHubSearchManager : IGitHubSearchManager, IDisposable
             Log.Logger()?.ReportError(Name, "Failed creating GitHubSearchManager", e);
             Environment.FailFast(e.Message, e);
             return null;
+        }
+    }
+
+    public async Task SearchForGitHubIssuesOrPRs(Octokit.SearchIssuesRequest request, string initiator, SearchCategory category, IDeveloperId developerId, RequestOptions? options = null)
+    {
+        Log.Logger()?.ReportInfo(Name, $"Searching for issues or pull requests for widget {initiator}");
+        request.State = Octokit.ItemState.Open;
+        request.Archived = false;
+        request.PerPage = 10;
+        request.SortField = Octokit.IssueSearchSort.Updated;
+        request.Order = Octokit.SortDirection.Descending;
+
+        var client = GitHubClientProvider.Instance.GetClient(developerId.Url) ?? throw new InvalidOperationException($"Client does not exist for {developerId.Url}");
+
+        // Set is: parameter according to the search category.
+        // For the case we are searching for both we don't have to set the parameter
+        if (category.Equals(SearchCategory.Issues))
+        {
+            request.Is = new List<Octokit.IssueIsQualifier>() { Octokit.IssueIsQualifier.Issue };
+        }
+        else if (category.Equals(SearchCategory.PullRequests))
+        {
+            request.Is = new List<Octokit.IssueIsQualifier>() { Octokit.IssueIsQualifier.PullRequest };
+        }
+
+        var octokitResult = await client.Search.SearchIssues(request);
+        if (octokitResult == null)
+        {
+            Log.Logger()?.ReportDebug($"No issues or PRs found.");
+            SendResultsAvailable(new List<Octokit.Issue>(), initiator);
+        }
+        else
+        {
+            Log.Logger()?.ReportDebug(Name, $"Results contain {octokitResult.Items.Count} items.");
+            SendResultsAvailable(octokitResult.Items, initiator);
         }
     }
 

--- a/src/GitHubExtension/DataManager/GitHubSearchManger.cs
+++ b/src/GitHubExtension/DataManager/GitHubSearchManger.cs
@@ -4,7 +4,6 @@
 using GitHubExtension.Client;
 using GitHubExtension.DataManager;
 using GitHubExtension.DataModel;
-using Microsoft.Windows.DevHome.SDK;
 
 namespace GitHubExtension;
 
@@ -31,41 +30,6 @@ public partial class GitHubSearchManager : IGitHubSearchManager, IDisposable
             Log.Logger()?.ReportError(Name, "Failed creating GitHubSearchManager", e);
             Environment.FailFast(e.Message, e);
             return null;
-        }
-    }
-
-    public async Task SearchForGitHubIssuesOrPRs(Octokit.SearchIssuesRequest request, string initiator, SearchCategory category, IDeveloperId developerId, RequestOptions? options = null)
-    {
-        Log.Logger()?.ReportInfo(Name, $"Searching for issues or pull requests for widget {initiator}");
-        request.State = Octokit.ItemState.Open;
-        request.Archived = false;
-        request.PerPage = 10;
-        request.SortField = Octokit.IssueSearchSort.Updated;
-        request.Order = Octokit.SortDirection.Descending;
-
-        var client = GitHubClientProvider.Instance.GetClient(developerId.Url) ?? throw new InvalidOperationException($"Client does not exist for {developerId.Url}");
-
-        // Set is: parameter according to the search category.
-        // For the case we are searching for both we don't have to set the parameter
-        if (category.Equals(SearchCategory.Issues))
-        {
-            request.Is = new List<Octokit.IssueIsQualifier>() { Octokit.IssueIsQualifier.Issue };
-        }
-        else if (category.Equals(SearchCategory.PullRequests))
-        {
-            request.Is = new List<Octokit.IssueIsQualifier>() { Octokit.IssueIsQualifier.PullRequest };
-        }
-
-        var octokitResult = await client.Search.SearchIssues(request);
-        if (octokitResult == null)
-        {
-            Log.Logger()?.ReportDebug($"No issues or PRs found.");
-            SendResultsAvailable(new List<Octokit.Issue>(), initiator);
-        }
-        else
-        {
-            Log.Logger()?.ReportDebug(Name, $"Results contain {octokitResult.Items.Count} items.");
-            SendResultsAvailable(octokitResult.Items, initiator);
         }
     }
 

--- a/src/GitHubExtension/DataManager/IGitHubSearchManager.cs
+++ b/src/GitHubExtension/DataManager/IGitHubSearchManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using GitHubExtension.DataManager;
-using Microsoft.Windows.DevHome.SDK;
 
 namespace GitHubExtension;
 

--- a/src/GitHubExtension/DataManager/IGitHubSearchManager.cs
+++ b/src/GitHubExtension/DataManager/IGitHubSearchManager.cs
@@ -9,6 +9,4 @@ namespace GitHubExtension;
 public interface IGitHubSearchManager : IDisposable
 {
     Task SearchForGitHubIssuesOrPRs(Octokit.SearchIssuesRequest request, string initiator, SearchCategory category, RequestOptions? options = null);
-
-    Task SearchForGitHubIssuesOrPRs(Octokit.SearchIssuesRequest request, string initiator, SearchCategory category, IDeveloperId developerId, RequestOptions? options = null);
 }

--- a/src/GitHubExtension/DataManager/IGitHubSearchManager.cs
+++ b/src/GitHubExtension/DataManager/IGitHubSearchManager.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT license.
 
 using GitHubExtension.DataManager;
+using Microsoft.Windows.DevHome.SDK;
 
 namespace GitHubExtension;
 
 public interface IGitHubSearchManager : IDisposable
 {
     Task SearchForGitHubIssuesOrPRs(Octokit.SearchIssuesRequest request, string initiator, SearchCategory category, RequestOptions? options = null);
+
+    Task SearchForGitHubIssuesOrPRs(Octokit.SearchIssuesRequest request, string initiator, SearchCategory category, IDeveloperId developerId, RequestOptions? options = null);
 }

--- a/src/GitHubExtension/DataModel/DataObjects/Issue.cs
+++ b/src/GitHubExtension/DataModel/DataObjects/Issue.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Globalization;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using GitHubExtension.Helpers;

--- a/src/GitHubExtension/DeveloperId/CredentialVault.cs
+++ b/src/GitHubExtension/DeveloperId/CredentialVault.cs
@@ -126,7 +126,7 @@ internal static class CredentialVault
         }
     }
 
-    public static IEnumerable<string> GetAllSavedLoginIds()
+    public static IEnumerable<string> GetAllSavedLoginIdsOrUrls()
     {
         var ptrToCredential = IntPtr.Zero;
 

--- a/src/GitHubExtension/DeveloperId/CredentialVault.cs
+++ b/src/GitHubExtension/DeveloperId/CredentialVault.cs
@@ -76,8 +76,16 @@ public class CredentialVault : ICredentialVault
             var isCredentialRetrieved = CredRead(credentialNameToRetrieve, CRED_TYPE.GENERIC, 0, out ptrToCredential);
             if (!isCredentialRetrieved)
             {
-                Log.Logger()?.ReportError($"Retrieving credentials from Credential Manager has failed for {loginId}");
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                var error = Marshal.GetLastWin32Error();
+                Log.Logger()?.ReportError($"Retrieving credentials from Credential Manager has failed for {loginId} with {error}");
+
+                // NotFound is expected and can be ignored.
+                if (error == 1168)
+                {
+                    return null;
+                }
+
+                throw new Win32Exception(error);
             }
 
             CREDENTIAL credentialObject;

--- a/src/GitHubExtension/DeveloperId/DeveloperId.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperId.cs
@@ -55,7 +55,8 @@ public class DeveloperId : IDeveloperId
             return RefreshDeveloperId();
         }
 
-        return CredentialVault.GetCredentialFromLocker(Url);
+        var credential = CredentialVault.GetInstance().GetCredentials(Url) ?? throw new InvalidOperationException("Invalid credential present for valid DeveloperId");
+        return credential;
     }
 
     public Windows.Security.Credentials.PasswordCredential RefreshDeveloperId()
@@ -63,7 +64,7 @@ public class DeveloperId : IDeveloperId
         // Setting to MaxValue, since GitHub doesn't forcibly expire tokens currently.
         CredentialExpiryTime = DateTime.MaxValue;
         DeveloperIdProvider.GetInstance().RefreshDeveloperId(this);
-        var credential = CredentialVault.GetCredentialFromLocker(Url);
+        var credential = CredentialVault.GetInstance().GetCredentials(Url) ?? throw new InvalidOperationException("Invalid credential present for valid DeveloperId");
         GitHubClient.Credentials = new (credential.Password);
         return credential;
     }

--- a/src/GitHubExtension/DeveloperId/DeveloperId.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperId.cs
@@ -55,7 +55,7 @@ public class DeveloperId : IDeveloperId
             return RefreshDeveloperId();
         }
 
-        return CredentialVault.GetCredentialFromLocker(LoginId);
+        return CredentialVault.GetCredentialFromLocker(Url);
     }
 
     public Windows.Security.Credentials.PasswordCredential RefreshDeveloperId()
@@ -63,7 +63,7 @@ public class DeveloperId : IDeveloperId
         // Setting to MaxValue, since GitHub doesn't forcibly expire tokens currently.
         CredentialExpiryTime = DateTime.MaxValue;
         DeveloperIdProvider.GetInstance().RefreshDeveloperId(this);
-        var credential = CredentialVault.GetCredentialFromLocker(LoginId);
+        var credential = CredentialVault.GetCredentialFromLocker(Url);
         GitHubClient.Credentials = new (credential.Password);
         return credential;
     }

--- a/src/GitHubExtension/DeveloperId/DeveloperId.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperId.cs
@@ -55,7 +55,7 @@ public class DeveloperId : IDeveloperId
             return RefreshDeveloperId();
         }
 
-        var credential = CredentialVault.GetInstance().GetCredentials(Url) ?? throw new InvalidOperationException("Invalid credential present for valid DeveloperId");
+        var credential = DeveloperIdProvider.GetInstance().GetCredentials(this) ?? throw new InvalidOperationException("Invalid credential present for valid DeveloperId");
         return credential;
     }
 
@@ -64,7 +64,7 @@ public class DeveloperId : IDeveloperId
         // Setting to MaxValue, since GitHub doesn't forcibly expire tokens currently.
         CredentialExpiryTime = DateTime.MaxValue;
         DeveloperIdProvider.GetInstance().RefreshDeveloperId(this);
-        var credential = CredentialVault.GetInstance().GetCredentials(Url) ?? throw new InvalidOperationException("Invalid credential present for valid DeveloperId");
+        var credential = DeveloperIdProvider.GetInstance().GetCredentials(this) ?? throw new InvalidOperationException("Invalid credential present for valid DeveloperId");
         GitHubClient.Credentials = new (credential.Password);
         return credential;
     }

--- a/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -52,9 +52,15 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         lock (DeveloperIdsLock)
         {
             DeveloperIds ??= new List<DeveloperId>();
-
-            // Retrieve and populate Logged in DeveloperIds from previous launch.
-            RestoreDeveloperIds(CredentialVault.GetAllSavedLoginIds());
+            try
+            {
+                // Retrieve and populate Logged in DeveloperIds from previous launch.
+                RestoreDeveloperIds(CredentialVault.GetAllSavedLoginIds());
+            }
+            catch (Exception error)
+            {
+                Log.Logger()?.ReportError($"Error while restoring DeveloperIds: {error.Message}. Proceeding without restoring.");
+            }
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Security;
 using Microsoft.UI;
 using Microsoft.Windows.DevHome.SDK;
 using Octokit;
@@ -93,13 +94,35 @@ public class DeveloperIdProvider : IDeveloperIdProvider
 
             oauthRequest.AwaitCompletion();
 
-            var devId = CreateOrUpdateDeveloperId(oauthRequest);
+            var devId = CreateOrUpdateDeveloperIdFromOauthRequest(oauthRequest);
             oauthRequest.Dispose();
 
             Log.Logger()?.ReportInfo($"New DeveloperId logged in");
 
             return devId as IDeveloperId;
         }).AsAsyncOperation();
+    }
+
+    private DeveloperId LoginNewDeveloperIdWithPAT(Uri hostAddress, SecureString personalAccessToken)
+    {
+        try
+        {
+            GitHubClient gitHubClient = new (new ProductHeaderValue(Constants.DEV_HOME_APPLICATION_NAME), hostAddress);
+            var credentials = new Credentials(new System.Net.NetworkCredential(string.Empty, personalAccessToken).Password);
+            gitHubClient.Credentials = credentials;
+            var newUser = gitHubClient.User.Current().Result;
+            DeveloperId developerId = new (newUser.Login, newUser.Name, newUser.Email, newUser.Url, gitHubClient);
+            SaveOrOverwriteDeveloperId(developerId, personalAccessToken);
+
+            Log.Logger()?.ReportInfo($"{developerId.LoginId} logged in with PAT flow to {developerId.GetHostAddress()}");
+
+            return developerId;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger()?.ReportError($"Error while logging in with PAT to {hostAddress.AbsoluteUri} : {ex.Message}");
+            throw;
+        }
     }
 
     private OAuthRequest? LoginNewDeveloperId()
@@ -208,10 +231,8 @@ public class DeveloperIdProvider : IDeveloperIdProvider
     }
 
     // Internal Functions.
-    private DeveloperId CreateOrUpdateDeveloperId(OAuthRequest oauthRequest)
+    private void SaveOrOverwriteDeveloperId(DeveloperId newDeveloperId, SecureString accessToken)
     {
-        // Query necessary data and populate Developer Id.
-        var newDeveloperId = oauthRequest.RetrieveDeveloperId();
         var duplicateDeveloperIds = DeveloperIds.Where(d => d.Url.Equals(newDeveloperId.Url, StringComparison.OrdinalIgnoreCase));
 
         if (duplicateDeveloperIds.Any())
@@ -220,7 +241,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
             try
             {
                 // Save the credential to Credential Vault.
-                CredentialVault.SaveAccessTokenToVault(duplicateDeveloperIds.Single().LoginId, oauthRequest.AccessToken);
+                CredentialVault.SaveAccessTokenToVault(duplicateDeveloperIds.Single().LoginId, accessToken);
 
                 try
                 {
@@ -244,7 +265,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
                 DeveloperIds.Add(newDeveloperId);
             }
 
-            CredentialVault.SaveAccessTokenToVault(newDeveloperId.LoginId, oauthRequest.AccessToken);
+            CredentialVault.SaveAccessTokenToVault(newDeveloperId.LoginId, accessToken);
 
             try
             {
@@ -255,6 +276,22 @@ public class DeveloperIdProvider : IDeveloperIdProvider
                 Log.Logger()?.ReportError($"LoggedIn event signaling failed: {error}");
             }
         }
+    }
+
+    private DeveloperId CreateOrUpdateDeveloperIdFromOauthRequest(OAuthRequest oauthRequest)
+    {
+        // Query necessary data and populate Developer Id.
+        var newDeveloperId = oauthRequest.RetrieveDeveloperId();
+        var accessToken = oauthRequest.AccessToken;
+        if (accessToken is null)
+        {
+            Log.Logger()?.ReportError($"Invalid AccessToken");
+            throw new InvalidOperationException();
+        }
+
+        SaveOrOverwriteDeveloperId(newDeveloperId, accessToken);
+
+        Log.Logger()?.ReportInfo($"{newDeveloperId.LoginId} logged in with OAuth flow to {newDeveloperId.GetHostAddress()}");
 
         return newDeveloperId;
     }

--- a/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -166,7 +166,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, new ArgumentNullException(nameof(developerId)), "The developer account to log out does not exist", "Unable to find DeveloperId to logout");
             }
 
-            CredentialVault.RemoveAccessTokenFromVault(developerIdToLogout.LoginId);
+            CredentialVault.RemoveAccessTokenFromVault(developerIdToLogout.Url);
             DeveloperIds?.Remove(developerIdToLogout);
         }
 
@@ -272,7 +272,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
                 DeveloperIds.Add(newDeveloperId);
             }
 
-            CredentialVault.SaveAccessTokenToVault(newDeveloperId.LoginId, accessToken);
+            CredentialVault.SaveAccessTokenToVault(newDeveloperId.Url, accessToken);
 
             try
             {

--- a/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -315,6 +315,10 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
 
     private void RestoreDeveloperIds(IEnumerable<string> loginIdsAndUrls)
     {
+        // We take loginIds or Urls here because in older versions of DevHome, we used loginIds to save credentials.
+        // In newer versions, we use Urls to save credentials.
+        // So, we need to check if loginId is currently used to save credential, and if so, replace it with URL.
+        // This is a temporary fix, and we should replace this logic once we are sure that most users have updated to newer versions of DevHome.
         foreach (var loginIdOrUrl in loginIdsAndUrls)
         {
             var isUrl = loginIdOrUrl.Contains('/');
@@ -378,6 +382,10 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
     public void Dispose()
     {
         GC.SuppressFinalize(this);
+        lock (AuthenticationProviderLock)
+        {
+            singletonDeveloperIdProvider = null;
+        }
     }
 
     public IAsyncOperation<DeveloperIdResult> ShowLogonSession(WindowId windowHandle) => throw new NotImplementedException();

--- a/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -56,7 +56,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
             try
             {
                 // Retrieve and populate Logged in DeveloperIds from previous launch.
-                RestoreDeveloperIds(CredentialVault.GetAllSavedLoginIdsOrUrls());
+                RestoreDeveloperIds(CredentialVault.GetInstance().GetAllCredentials());
             }
             catch (Exception error)
             {
@@ -166,7 +166,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, new ArgumentNullException(nameof(developerId)), "The developer account to log out does not exist", "Unable to find DeveloperId to logout");
             }
 
-            CredentialVault.RemoveAccessTokenFromVault(developerIdToLogout.Url);
+            CredentialVault.GetInstance().RemoveCredentials(developerIdToLogout.Url);
             DeveloperIds?.Remove(developerIdToLogout);
         }
 
@@ -248,7 +248,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
             try
             {
                 // Save the credential to Credential Vault.
-                CredentialVault.SaveAccessTokenToVault(duplicateDeveloperIds.Single().Url, accessToken);
+                CredentialVault.GetInstance().SaveCredentials(duplicateDeveloperIds.Single().Url, accessToken);
 
                 try
                 {
@@ -272,7 +272,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
                 DeveloperIds.Add(newDeveloperId);
             }
 
-            CredentialVault.SaveAccessTokenToVault(newDeveloperId.Url, accessToken);
+            CredentialVault.GetInstance().SaveCredentials(newDeveloperId.Url, accessToken);
 
             try
             {
@@ -314,7 +314,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
 
             GitHubClient gitHubClient = new (new ProductHeaderValue(Constants.DEV_HOME_APPLICATION_NAME), hostAddress)
             {
-                Credentials = new (CredentialVault.GetCredentialFromLocker(loginIdOrUrl).Password),
+                Credentials = new (CredentialVault.GetInstance().GetCredentials(loginIdOrUrl)?.Password),
             };
 
             var user = gitHubClient.User.Current().Result;
@@ -333,10 +333,10 @@ public class DeveloperIdProvider : IDeveloperIdProvider
             {
                 try
                 {
-                    CredentialVault.SaveAccessTokenToVault(
+                    CredentialVault.GetInstance().SaveCredentials(
                         user.Url,
-                        new NetworkCredential(string.Empty, CredentialVault.GetCredentialFromLocker(loginIdOrUrl).Password).SecurePassword);
-                    CredentialVault.RemoveAccessTokenFromVault(loginIdOrUrl);
+                        new NetworkCredential(string.Empty, CredentialVault.GetInstance().GetCredentials(loginIdOrUrl)?.Password).SecurePassword);
+                    CredentialVault.GetInstance().RemoveCredentials(loginIdOrUrl);
                     Log.Logger()?.ReportInfo($"Replaced {loginIdOrUrl} with {user.Url} in CredentialManager");
                 }
                 catch (Exception error)

--- a/src/GitHubExtension/DeveloperId/Enums/LoginUIState.cs
+++ b/src/GitHubExtension/DeveloperId/Enums/LoginUIState.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+namespace GitHubExtension.DeveloperId;
+
+public enum LoginUIState
+{
+    // Login UI starts on the LoginPage.
+    LoginPage,
+
+    // Enterprise Server is selected on the LoginPage
+    EnterpriseServerPage,
+
+    // User has entered a server URL on the EnterpriseServerPage
+    EnterpriseServerPATPage,
+
+    // The user has clicked the "Sign in with GitHub" button and is waiting for the GitHub login page to load.
+    WaitingPage,
+
+    // Login has failed and the user is shown the LoginFailedPage.
+    LoginFailedPage,
+
+    // Login has succeeded and the user is shown the LoginSucceededPage.
+    LoginSucceededPage,
+
+    // LoginUI is not visible and is in the process of being disposed.
+    End,
+}

--- a/src/GitHubExtension/DeveloperId/ICredentialVault.cs
+++ b/src/GitHubExtension/DeveloperId/ICredentialVault.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Security;
+using Windows.Security.Credentials;
+
+namespace GitHubExtension.DeveloperId;
+
+internal interface ICredentialVault
+{
+    PasswordCredential? GetCredentials(string loginId);
+
+    void RemoveCredentials(string loginId);
+
+    void SaveCredentials(string loginId, SecureString? accessToken);
+
+    IEnumerable<string> GetAllCredentials();
+
+    void RemoveAllCredentials();
+}

--- a/src/GitHubExtension/DeveloperId/IDeveloperIdProviderInternal.cs
+++ b/src/GitHubExtension/DeveloperId/IDeveloperIdProviderInternal.cs
@@ -6,11 +6,19 @@ using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
 
 namespace GitHubExtension.DeveloperId;
+
+// This internal interface extends the public interface IDeveloperIdProvider
 public interface IDeveloperIdProviderInternal : IDeveloperIdProvider
 {
+    // This method triggers login flow for a new developer id through the browser.
+    // This is called when the user clicks on the "Sign in" button in LoginUI popup.
     public IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync();
 
+    // This method triggers login flow for a new developer id using the provided personal access token.
+    // This will not open the browser. This is used when the user selects the "Sign in with GHES"
+    // option in LoginUI popup.
     public DeveloperId LoginNewDeveloperIdWithPAT(Uri hostAddress, SecureString personalAccessToken);
 
+    // This method returns the list of developer id objects that are currently logged in.
     public IEnumerable<DeveloperId> GetLoggedInDeveloperIdsInternal();
 }

--- a/src/GitHubExtension/DeveloperId/IDeveloperIdProviderInternal.cs
+++ b/src/GitHubExtension/DeveloperId/IDeveloperIdProviderInternal.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Security;
+using Microsoft.Windows.DevHome.SDK;
+using Windows.Foundation;
+
+namespace GitHubExtension.DeveloperId;
+public interface IDeveloperIdProviderInternal : IDeveloperIdProvider
+{
+    public IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync();
+
+    public DeveloperId LoginNewDeveloperIdWithPAT(Uri hostAddress, SecureString personalAccessToken);
+
+    public IEnumerable<DeveloperId> GetLoggedInDeveloperIdsInternal();
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/EndPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EndPage.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+namespace GitHubExtension.DeveloperId.LoginUI;
+
+internal class EndPage : LoginUIPage
+{
+    public EndPage()
+        : base(LoginUIState.End)
+    {
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
@@ -17,7 +17,7 @@ internal class EnterpriseServerPATPage : LoginUIPage
             EnterpriseServerPATPageInputValue = inputPAT ?? string.Empty,
             EnterpriseServerPATPageErrorValue = errorText ?? string.Empty,
             EnterpriseServerPATPageErrorVisible = !string.IsNullOrEmpty(errorText),
-            EnterpriseServerPATPageCreatePATUrlValue = hostAddress?.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped) + $"/settings/tokens/new?scopes=read:user,notifications,repo,read:org&description=DevHomePAT",
+            EnterpriseServerPATPageCreatePATUrlValue = hostAddress?.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped) + $"/settings/tokens/new?scopes=read:user,notifications,repo,read:org&description=DevHomeGitHubExtension",
             EnterpriseServerPATPageServerUrlValue = hostAddress?.OriginalString ?? string.Empty,
         };
     }

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
@@ -1,24 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using System.Security;
 using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;
 
 internal class EnterpriseServerPATPage : LoginUIPage
 {
-    public EnterpriseServerPATPage(Uri hostAddress, string errorText, string? inputPAT)
+    public EnterpriseServerPATPage(Uri hostAddress, string errorText, SecureString inputPAT)
         : base(LoginUIState.EnterpriseServerPATPage)
     {
         Data = new PageData()
         {
-            EnterpriseServerPATPageInputValue = inputPAT ?? string.Empty,
+            EnterpriseServerPATPageInputValue = new System.Net.NetworkCredential(string.Empty, inputPAT).Password ?? string.Empty,
             EnterpriseServerPATPageErrorValue = errorText ?? string.Empty,
             EnterpriseServerPATPageErrorVisible = !string.IsNullOrEmpty(errorText),
             EnterpriseServerPATPageCreatePATUrlValue = hostAddress?.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped) + $"/settings/tokens/new?scopes=read:user,notifications,repo,read:org&description=DevHomeGitHubExtension",
-            EnterpriseServerPATPageServerUrlValue = hostAddress?.OriginalString ?? string.Empty,
+            EnterpriseServerPATPageServerUrlValue = hostAddress?.Host ?? string.Empty,
         };
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitHubExtension.DeveloperId.LoginUI;
+
+internal class EnterpriseServerPATPage : LoginUIPage
+{
+    public EnterpriseServerPATPage(Uri hostAddress, string errorText, string? inputPAT)
+        : base(LoginUIState.EnterpriseServerPATPage)
+    {
+        Data = new PageData()
+        {
+            EnterpriseServerPATPageInputValue = inputPAT ?? string.Empty,
+            EnterpriseServerPATPageErrorValue = errorText ?? string.Empty,
+            EnterpriseServerPATPageErrorVisible = !string.IsNullOrEmpty(errorText),
+            EnterpriseServerPATPageCreatePATUrlValue = hostAddress?.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped) + $"/settings/tokens/new?scopes=read:user,notifications,repo,read:org&description=DevHomePAT",
+            EnterpriseServerPATPageServerUrlValue = hostAddress?.OriginalString ?? string.Empty,
+        };
+    }
+
+    internal class PageData : ILoginUIPageData
+    {
+        public string EnterpriseServerPATPageInputValue { get; set; } = string.Empty;
+
+        public bool EnterpriseServerPATPageErrorVisible { get; set; }
+
+        public string EnterpriseServerPATPageErrorValue { get; set; } = string.Empty;
+
+        public string EnterpriseServerPATPageCreatePATUrlValue { get; set; } = "https://github.com/";
+
+        public string EnterpriseServerPATPageServerUrlValue { get; set; } = "https://github.com/";
+
+        public string GetJson()
+        {
+            return JsonSerializer.Serialize(
+            this,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                IncludeFields = true,
+            });
+        }
+    }
+
+    internal class ActionPayload : SubmitActionPayload
+    {
+        public string? URL
+        {
+            get; set;
+        }
+    }
+
+    internal class InputPayload
+    {
+        public string? PAT
+        {
+            get; set;
+        }
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;
 
@@ -35,14 +36,7 @@ internal class EnterpriseServerPATPage : LoginUIPage
 
         public string GetJson()
         {
-            return JsonSerializer.Serialize(
-            this,
-            new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-                IncludeFields = true,
-            });
+            return Json.Stringify(this);
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitHubExtension.DeveloperId.LoginUI;
+
+internal class EnterpriseServerPage : LoginUIPage
+{
+    public EnterpriseServerPage(Uri? hostAddress, string errorText)
+        : base(LoginUIState.EnterpriseServerPage)
+    {
+        Data = new PageData()
+        {
+            EnterpriseServerInputValue = hostAddress?.ToString() ?? string.Empty,
+            EnterpriseServerPageErrorValue = errorText ?? string.Empty,
+            EnterpriseServerPageErrorVisible = !string.IsNullOrEmpty(errorText),
+        };
+    }
+
+    public EnterpriseServerPage(string hostAddress, string errorText)
+        : base(LoginUIState.EnterpriseServerPage)
+    {
+        Data = new PageData()
+        {
+            EnterpriseServerInputValue = hostAddress,
+            EnterpriseServerPageErrorValue = errorText ?? string.Empty,
+            EnterpriseServerPageErrorVisible = !string.IsNullOrEmpty(errorText),
+        };
+    }
+
+    internal class PageData : ILoginUIPageData
+    {
+        public string EnterpriseServerInputValue { get; set; } = string.Empty;
+
+        // Default is false
+        public bool EnterpriseServerPageErrorVisible { get; set; }
+
+        public string EnterpriseServerPageErrorValue { get; set; } = string.Empty;
+
+        public string GetJson()
+        {
+            return JsonSerializer.Serialize(
+            this,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                IncludeFields = true,
+            });
+        }
+    }
+
+    internal class ActionPayload : SubmitActionPayload
+    {
+    }
+
+    internal class InputPayload
+    {
+        public string? EnterpriseServer
+        {
+            get; set;
+        }
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;
 
@@ -41,14 +42,7 @@ internal class EnterpriseServerPage : LoginUIPage
 
         public string GetJson()
         {
-            return JsonSerializer.Serialize(
-            this,
-            new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-                IncludeFields = true,
-            });
+            return Json.Stringify(this);
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitHubExtension.DeveloperId.LoginUI;
+
+internal class LoginFailedPage : LoginUIPage
+{
+    public LoginFailedPage()
+        : base(LoginUIState.LoginFailedPage)
+    {
+        Data = new LoginFailedPageData();
+    }
+
+    internal class LoginFailedPageData : ILoginUIPageData
+    {
+        public string GetJson()
+        {
+            return JsonSerializer.Serialize(
+            this,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                IncludeFields = true,
+            });
+        }
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;
 
@@ -18,14 +19,7 @@ internal class LoginFailedPage : LoginUIPage
     {
         public string GetJson()
         {
-            return JsonSerializer.Serialize(
-            this,
-            new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-                IncludeFields = true,
-            });
+            return Json.Stringify(this);
         }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
@@ -31,5 +31,9 @@ internal class LoginPage : LoginUIPage
 
     internal class ActionPayload : SubmitActionPayload
     {
+        public bool IsEnterprise()
+        {
+            return this.Id == "Enterprise";
+        }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitHubExtension.DeveloperId.LoginUI;
+
+internal class LoginPage : LoginUIPage
+{
+    public LoginPage()
+        : base(LoginUIState.LoginPage)
+    {
+        Data = new PageData();
+    }
+
+    internal class PageData : ILoginUIPageData
+    {
+        public string GetJson()
+        {
+            return JsonSerializer.Serialize(
+            this,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                IncludeFields = true,
+            });
+        }
+    }
+
+    internal class ActionPayload : SubmitActionPayload
+    {
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;
 
@@ -18,14 +19,7 @@ internal class LoginPage : LoginUIPage
     {
         public string GetJson()
         {
-            return JsonSerializer.Serialize(
-            this,
-            new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-                IncludeFields = true,
-            });
+            return Json.Stringify(this);
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
@@ -25,14 +25,7 @@ internal class LoginSucceededPage : LoginUIPage
 
         public string GetJson()
         {
-            return JsonSerializer.Serialize(
-            this,
-            new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-                IncludeFields = true,
-            });
+            return Json.Stringify(this);
         }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using ResourceLoader = Microsoft.Windows.ApplicationModel.Resources.ResourceLoader;
 
@@ -13,10 +14,9 @@ internal class LoginSucceededPage : LoginUIPage
     public LoginSucceededPage(IDeveloperId developerId)
         : base(LoginUIState.LoginSucceededPage)
     {
-        var resourceLoader = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "GitHubExtension/Resources");
         Data = new LoginSucceededPageData()
         {
-            Message = $"{developerId.LoginId} {resourceLoader.GetString("LoginUI_LoginSucceededPage_text")}",
+            Message = $"{developerId.LoginId} {Resources.GetResource("LoginUI_LoginSucceededPage_text")}",
         };
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
@@ -15,7 +15,7 @@ internal class LoginSucceededPage : LoginUIPage
     {
         Data = new LoginSucceededPageData()
         {
-            Message = $"{developerId.LoginId} {Resources.GetResource("LoginUI_LoginSucceededPage_text")}",
+            Message = $"{Resources.GetResource("LoginUI_LoginSucceededPage_text").Replace("{User}", developerId.LoginId)}",
         };
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Windows.DevHome.SDK;
+using ResourceLoader = Microsoft.Windows.ApplicationModel.Resources.ResourceLoader;
+
+namespace GitHubExtension.DeveloperId.LoginUI;
+
+internal class LoginSucceededPage : LoginUIPage
+{
+    public LoginSucceededPage(IDeveloperId developerId)
+        : base(LoginUIState.LoginSucceededPage)
+    {
+        var resourceLoader = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "GitHubExtension/Resources");
+        Data = new LoginSucceededPageData()
+        {
+            Message = $"{developerId.LoginId} {resourceLoader.GetString("LoginUI_LoginSucceededPage_text")}",
+        };
+    }
+
+    internal class LoginSucceededPageData : ILoginUIPageData
+    {
+        public string? Message { get; set; } = string.Empty;
+
+        public string GetJson()
+        {
+            return JsonSerializer.Serialize(
+            this,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                IncludeFields = true,
+            });
+        }
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
-using ResourceLoader = Microsoft.Windows.ApplicationModel.Resources.ResourceLoader;
 
 namespace GitHubExtension.DeveloperId.LoginUI;
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -353,7 +353,7 @@ internal class LoginUIPage
             ""inlines"": [
                 {
                     ""type"": ""TextRun"",
-                    ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_Text")} " + @"""
+                    ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_Text1")} " + @"""
                 },
                 {
                     ""type"": ""TextRun"",
@@ -362,6 +362,10 @@ internal class LoginUIPage
                         ""type"": ""Action.OpenUrl"",
                         ""url"": ""${EnterpriseServerPATPageCreatePATUrlValue}""
                     }
+                },
+                {
+                    ""type"": ""TextRun"",
+                    ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_Text2")} " + @"""
                 }
             ]
         },

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -590,5 +590,10 @@ internal class LoginUIPage
         {
             return this.Type == "Action.OpenUrl";
         }
+
+        public bool IsSubmitAction()
+        {
+            return this.Type == "Action.Submit";
+        }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 
@@ -39,7 +41,7 @@ internal class LoginUIPage
         return adaptiveCard.Update(_template, _data?.GetJson(), Enum.GetName(typeof(LoginUIState), _state));
     }
 
-    private string GetTemplate(LoginUIState loginUIState)
+    private static string GetTemplate(LoginUIState loginUIState)
     {
         var loginPage = @"
 {

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -1,0 +1,590 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GitHubExtension.DeveloperId.LoginUI;
+using Microsoft.Windows.DevHome.SDK;
+using ResourceLoader = Microsoft.Windows.ApplicationModel.Resources.ResourceLoader;
+
+namespace GitHubExtension.DeveloperId;
+
+internal class LoginUIPage
+{
+    private readonly string _template;
+    private readonly LoginUIState _state;
+    private ILoginUIPageData? _data;
+
+    public interface ILoginUIPageData
+    {
+        public abstract string GetJson();
+    }
+
+    protected ILoginUIPageData Data
+    {
+        get => _data ?? throw new InvalidOperationException();
+        set => _data = value;
+    }
+
+    public LoginUIPage(LoginUIState state)
+    {
+        _template = GetTemplate(state);
+        _state = state;
+    }
+
+    public ProviderOperationResult UpdateExtensionAdaptiveCard(IExtensionAdaptiveCard adaptiveCard)
+    {
+        if (adaptiveCard == null)
+        {
+            throw new ArgumentNullException(nameof(adaptiveCard));
+        }
+
+        var x = _data?.GetJson();
+        return adaptiveCard.Update(_template, x, Enum.GetName(typeof(LoginUIState), _state));
+    }
+
+    private string GetTemplate(LoginUIState loginUIState)
+    {
+        var loader = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "GitHubExtension/Resources");
+
+        var loginPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""ColumnSet"",
+            ""spacing"": ""Large"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""items"": [
+                        {
+                            ""type"": ""Image"",
+                            ""style"": ""Person"",
+                            ""url"": ""https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"",
+                            ""size"": ""small"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""weight"": ""Bolder"",
+                            ""text"": """ + $"{loader.GetString("LoginUI_LoginPage_Heading")}" + @""",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""Small"",
+                            ""size"": ""large""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": """ + $"{loader.GetString("LoginUI_LoginPage_Subheading")}" + @""",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None"",
+                            ""size"": ""small""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": """",
+                            ""wrap"": true,
+                            ""spacing"": ""Large"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""isSubtle"": true
+                        }
+                    ],
+                    ""width"": ""stretch"",
+                    ""separator"": true,
+                    ""spacing"": ""Medium""
+                }
+            ]
+        },
+        {
+            ""type"": ""Table"",
+            ""columns"": [
+                {
+                    ""width"": 1
+                }
+            ],
+            ""rows"": [
+                {
+                    ""type"": ""TableRow"",
+                    ""cells"": [
+                        {
+                            ""type"": ""TableCell"",
+                            ""items"": [
+                                {
+                                    ""type"": ""ActionSet"",
+                                    ""actions"": [
+                                        {
+                                            ""type"": ""Action.Submit"",
+                                            ""title"": """ + $"{loader.GetString("LoginUI_LoginPage_Button1Text")}" + @""",
+                                            ""tooltip"": """ + $"{loader.GetString("LoginUI_LoginPage_Button1ToolTip")}" + @""",
+                                            ""style"": ""positive"",
+                                            ""isEnabled"": true,
+                                            ""id"": ""Personal""
+                                        }
+                                    ],
+                                    ""horizontalAlignment"": ""Center"",
+                                    ""spacing"": ""None""
+                                }
+                            ],
+                            ""verticalContentAlignment"": ""Center"",
+                            ""height"": ""stretch"",
+                            ""spacing"": ""None"",
+                            ""horizontalAlignment"": ""Center""
+                        }
+                    ],
+                    ""horizontalAlignment"": ""Center"",
+                    ""height"": ""stretch"",
+                    ""horizontalCellContentAlignment"": ""Center"",
+                    ""verticalCellContentAlignment"": ""Center"",
+                    ""spacing"": ""None""
+                },
+                {
+                    ""type"": ""TableRow"",
+                    ""cells"": [
+                        {
+                            ""type"": ""TableCell"",
+                            ""items"": [
+                                {
+                                    ""type"": ""ActionSet"",
+                                    ""actions"": [
+                                        {
+                                            ""type"": ""Action.Submit"",
+                                            ""title"": """ + $"{loader.GetString("LoginUI_LoginPage_Button2Text")}" + @""",
+                                            ""isEnabled"": true,
+                                            ""tooltip"": """ + $"{loader.GetString("LoginUI_LoginPage_Button2ToolTip")}" + @""",
+                                            ""id"": ""Enterprise""
+                                        }
+                                    ],
+                                    ""spacing"": ""None"",
+                                    ""horizontalAlignment"": ""Center""
+                                }
+                            ],
+                            ""verticalContentAlignment"": ""Center"",
+                            ""spacing"": ""None"",
+                            ""horizontalAlignment"": ""Center""
+                        }
+                    ],
+                    ""spacing"": ""None"",
+                    ""horizontalAlignment"": ""Center"",
+                    ""horizontalCellContentAlignment"": ""Center"",
+                    ""verticalCellContentAlignment"": ""Center""
+                }
+            ],
+            ""firstRowAsHeaders"": false,
+            ""spacing"": ""Medium"",
+            ""horizontalAlignment"": ""Center"",
+            ""horizontalCellContentAlignment"": ""Center"",
+            ""verticalCellContentAlignment"": ""Center"",
+            ""showGridLines"": false
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""350px"",
+    ""verticalContentAlignment"": ""Top"",
+    ""rtl"": false
+}
+";
+
+        var enterpriseServerPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""ColumnSet"",
+            ""spacing"": ""Large"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""items"": [
+                        {
+                            ""type"": ""Image"",
+                            ""style"": ""Person"",
+                            ""url"": ""https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"",
+                            ""size"": ""Small"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""weight"": ""Bolder"",
+                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Heading")}" + @""",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""Small"",
+                            ""size"": ""Large""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Subheading")}" + @""",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None"",
+                            ""size"": ""Small""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": """",
+                            ""wrap"": true,
+                            ""spacing"": ""Large"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""isSubtle"": true
+                        }
+                    ],
+                    ""width"": ""stretch"",
+                    ""separator"": true,
+                    ""spacing"": ""Medium""
+                }
+            ]
+        },
+        {
+            ""type"": ""Input.Text"",
+            ""placeholder"": """ + $"{loader.GetString("LoginUI_EnterprisePage_InputText_PlaceHolder")}" + @""",
+            ""id"": ""EnterpriseServer"",
+            ""style"": ""Url"",
+            ""spacing"": ""ExtraLarge"",
+            ""value"": ""${EnterpriseServerInputValue}""
+        },
+        {
+            ""type"": ""TextBlock"",
+            ""text"": ""${EnterpriseServerPageErrorValue}"",
+            ""wrap"": true,
+            ""horizontalAlignment"": ""Left"",
+            ""spacing"": ""small"",
+            ""size"": ""small"",
+            ""color"": ""attention"",
+            ""isVisible"": ""${EnterpriseServerPageErrorVisible}""
+        },
+        {
+            ""type"": ""ColumnSet"",
+            ""horizontalAlignment"": ""Center"",
+            ""height"": ""stretch"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Button_Cancel")}" + @""",
+                                    ""id"": ""Cancel"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Button_Next")}" + @""",
+                                    ""id"": ""Next"",
+                                    ""style"": ""positive"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            ""spacing"": ""Small""
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""350px"",
+    ""verticalContentAlignment"": ""Top"",
+    ""rtl"": false
+}
+";
+
+        var enterpriseServerPATPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""ColumnSet"",
+            ""spacing"": ""Large"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""items"": [
+                        {
+                            ""type"": ""Image"",
+                            ""style"": ""Person"",
+                            ""url"": ""https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"",
+                            ""size"": ""Small"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""weight"": ""Bolder"",
+                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Heading")}" + @""",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""Small"",
+                            ""size"": ""Large""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Subheading")}" + @""",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None"",
+                            ""size"": ""Small""
+                        }
+                    ],
+                    ""width"": ""stretch"",
+                    ""separator"": true,
+                    ""spacing"": ""Medium""
+                }
+            ]
+        },
+        {
+            ""type"": ""RichTextBlock"",
+            ""inlines"": [
+                {
+                    ""type"": ""TextRun"",
+                    ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_Text")} " + @"""
+                },
+                {
+                    ""type"": ""TextRun"",
+                    ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_HighlightedText")}" + @""",
+                    ""selectAction"": {
+                        ""type"": ""Action.OpenUrl"",
+                        ""url"": ""${EnterpriseServerPATPageCreatePATUrlValue}""
+                    }
+                }
+            ]
+        },
+        {
+            ""type"": ""Input.Text"",
+            ""placeholder"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_InputText_PlaceHolder")}" + @""",
+            ""id"": ""PAT"",
+            ""spacing"": ""Large"",
+            ""value"": ""${EnterpriseServerPATPageInputValue}""
+        },
+        {
+            ""type"": ""TextBlock"",
+            ""text"": ""${EnterpriseServerPATPageErrorValue}"",
+            ""wrap"": true,
+            ""horizontalAlignment"": ""Left"",
+            ""spacing"": ""small"",
+            ""size"": ""small"",
+            ""color"": ""attention"",
+            ""isVisible"": ""${EnterpriseServerPATPageErrorVisible}""
+        },
+        {
+            ""type"": ""ColumnSet"",
+            ""horizontalAlignment"": ""Center"",
+            ""height"": ""stretch"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_Button_Cancel")}" + @""",
+                                    ""id"": ""Cancel"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_Button_Connect")}" + @""",
+                                    ""id"": ""Connect"",
+                                    ""style"": ""positive"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            ""spacing"": ""Small""
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""350px"",
+    ""verticalContentAlignment"": ""Top"",
+    ""rtl"": false
+}
+";
+
+        var waitingPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""TextBlock"",
+            ""text"": """ + $"{loader.GetString("LoginUI_WaitingPage_Text")}" + @""",
+            ""isSubtle"": false,
+            ""wrap"": true,
+            ""horizontalAlignment"": ""Center"",
+            ""spacing"": ""ExtraLarge"",
+            ""size"": ""Large"",
+            ""weight"": ""Lighter"",
+            ""height"": ""stretch"",
+            ""style"": ""heading""
+        },
+        {
+            ""type"" : ""TextBlock"",
+            ""text"": """ + $"{loader.GetString("LoginUI_WaitingPageBrowserLaunch_Text")}" + @""",
+            ""isSubtle"": false,
+            ""horizontalAlignment"": ""Center"",
+            ""weight"": ""Lighter""
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""100px""
+}
+";
+
+        var loginSucceededPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""TextBlock"",
+            ""text"": ""${message}"",
+            ""isSubtle"": false,
+            ""wrap"": true,
+            ""horizontalAlignment"": ""Center"",
+            ""spacing"": ""ExtraLarge"",
+            ""size"": ""Large"",
+            ""weight"": ""Lighter"",
+            ""style"": ""heading""
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""200px""
+}
+";
+
+        var loginFailedPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""TextBlock"",
+            ""text"": """ + $"{loader.GetString("LoginUI_LoginFailedPage_text1")}" + @""",
+            ""isSubtle"": false,
+            ""wrap"": true,
+            ""horizontalAlignment"": ""Center"",
+            ""spacing"": ""ExtraLarge"",
+            ""size"": ""Large"",
+            ""weight"": ""Lighter"",
+            ""style"": ""heading""
+        },
+        {
+            ""type"": ""TextBlock"",
+            ""text"": """ + $"{loader.GetString("LoginUI_LoginFailedPage_text2")}" + @""",
+            ""isSubtle"": true,
+            ""wrap"": true,
+            ""horizontalAlignment"": ""Center"",
+            ""size"": ""medium"",
+            ""weight"": ""Lighter""
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""200px""
+}
+";
+
+        switch (loginUIState)
+        {
+            case LoginUIState.LoginPage:
+                {
+                    return loginPage;
+                }
+
+            case LoginUIState.EnterpriseServerPage:
+                {
+                    return enterpriseServerPage;
+                }
+
+            case LoginUIState.EnterpriseServerPATPage:
+                {
+                    return enterpriseServerPATPage;
+                }
+
+            case LoginUIState.WaitingPage:
+                {
+                    return waitingPage;
+                }
+
+            case LoginUIState.LoginFailedPage:
+                {
+                    return loginFailedPage;
+                }
+
+            case LoginUIState.LoginSucceededPage:
+                {
+                    return loginSucceededPage;
+                }
+
+            default:
+                {
+                    throw new InvalidOperationException();
+                }
+        }
+    }
+
+    internal class SubmitActionPayload
+    {
+        public string? Id
+        {
+            get; set;
+        }
+
+        public string? Style
+        {
+            get; set;
+        }
+
+        public string? ToolTip
+        {
+            get; set;
+        }
+
+        public string? Title
+        {
+            get; set;
+        }
+
+        public string? Type
+        {
+            get; set;
+        }
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using GitHubExtension.DeveloperId.LoginUI;
+using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 using ResourceLoader = Microsoft.Windows.ApplicationModel.Resources.ResourceLoader;
 
@@ -39,14 +37,11 @@ internal class LoginUIPage
             throw new ArgumentNullException(nameof(adaptiveCard));
         }
 
-        var x = _data?.GetJson();
-        return adaptiveCard.Update(_template, x, Enum.GetName(typeof(LoginUIState), _state));
+        return adaptiveCard.Update(_template, _data?.GetJson(), Enum.GetName(typeof(LoginUIState), _state));
     }
 
     private string GetTemplate(LoginUIState loginUIState)
     {
-        var loader = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "GitHubExtension/Resources");
-
         var loginPage = @"
 {
     ""type"": ""AdaptiveCard"",
@@ -69,7 +64,7 @@ internal class LoginUIPage
                         {
                             ""type"": ""TextBlock"",
                             ""weight"": ""Bolder"",
-                            ""text"": """ + $"{loader.GetString("LoginUI_LoginPage_Heading")}" + @""",
+                            ""text"": """ + $"{Resources.GetResource("LoginUI_LoginPage_Heading")}" + @""",
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""Small"",
@@ -77,7 +72,7 @@ internal class LoginUIPage
                         },
                         {
                             ""type"": ""TextBlock"",
-                            ""text"": """ + $"{loader.GetString("LoginUI_LoginPage_Subheading")}" + @""",
+                            ""text"": """ + $"{Resources.GetResource("LoginUI_LoginPage_Subheading")}" + @""",
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""None"",
@@ -117,8 +112,8 @@ internal class LoginUIPage
                                     ""actions"": [
                                         {
                                             ""type"": ""Action.Submit"",
-                                            ""title"": """ + $"{loader.GetString("LoginUI_LoginPage_Button1Text")}" + @""",
-                                            ""tooltip"": """ + $"{loader.GetString("LoginUI_LoginPage_Button1ToolTip")}" + @""",
+                                            ""title"": """ + $"{Resources.GetResource("LoginUI_LoginPage_Button1Text")}" + @""",
+                                            ""tooltip"": """ + $"{Resources.GetResource("LoginUI_LoginPage_Button1ToolTip")}" + @""",
                                             ""style"": ""positive"",
                                             ""isEnabled"": true,
                                             ""id"": ""Personal""
@@ -151,9 +146,9 @@ internal class LoginUIPage
                                     ""actions"": [
                                         {
                                             ""type"": ""Action.Submit"",
-                                            ""title"": """ + $"{loader.GetString("LoginUI_LoginPage_Button2Text")}" + @""",
+                                            ""title"": """ + $"{Resources.GetResource("LoginUI_LoginPage_Button2Text")}" + @""",
                                             ""isEnabled"": true,
-                                            ""tooltip"": """ + $"{loader.GetString("LoginUI_LoginPage_Button2ToolTip")}" + @""",
+                                            ""tooltip"": """ + $"{Resources.GetResource("LoginUI_LoginPage_Button2ToolTip")}" + @""",
                                             ""id"": ""Enterprise""
                                         }
                                     ],
@@ -210,7 +205,7 @@ internal class LoginUIPage
                         {
                             ""type"": ""TextBlock"",
                             ""weight"": ""Bolder"",
-                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Heading")}" + @""",
+                            ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePage_Heading")}" + @""",
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""Small"",
@@ -218,7 +213,7 @@ internal class LoginUIPage
                         },
                         {
                             ""type"": ""TextBlock"",
-                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Subheading")}" + @""",
+                            ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePage_Subheading")}" + @""",
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""None"",
@@ -241,7 +236,7 @@ internal class LoginUIPage
         },
         {
             ""type"": ""Input.Text"",
-            ""placeholder"": """ + $"{loader.GetString("LoginUI_EnterprisePage_InputText_PlaceHolder")}" + @""",
+            ""placeholder"": """ + $"{Resources.GetResource("LoginUI_EnterprisePage_InputText_PlaceHolder")}" + @""",
             ""id"": ""EnterpriseServer"",
             ""style"": ""Url"",
             ""spacing"": ""ExtraLarge"",
@@ -271,7 +266,7 @@ internal class LoginUIPage
                             ""actions"": [
                                 {
                                     ""type"": ""Action.Submit"",
-                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Button_Cancel")}" + @""",
+                                    ""title"": """ + $"{Resources.GetResource("LoginUI_EnterprisePage_Button_Cancel")}" + @""",
                                     ""id"": ""Cancel"",
                                     ""role"": ""Button""
                                 }
@@ -288,7 +283,7 @@ internal class LoginUIPage
                             ""actions"": [
                                 {
                                     ""type"": ""Action.Submit"",
-                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Button_Next")}" + @""",
+                                    ""title"": """ + $"{Resources.GetResource("LoginUI_EnterprisePage_Button_Next")}" + @""",
                                     ""id"": ""Next"",
                                     ""style"": ""positive"",
                                     ""role"": ""Button""
@@ -331,7 +326,7 @@ internal class LoginUIPage
                         {
                             ""type"": ""TextBlock"",
                             ""weight"": ""Bolder"",
-                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Heading")}" + @""",
+                            ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePage_Heading")}" + @""",
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""Small"",
@@ -339,7 +334,7 @@ internal class LoginUIPage
                         },
                         {
                             ""type"": ""TextBlock"",
-                            ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePage_Subheading")}" + @""",
+                            ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePage_Subheading")}" + @""",
                             ""wrap"": true,
                             ""horizontalAlignment"": ""Center"",
                             ""spacing"": ""None"",
@@ -357,11 +352,11 @@ internal class LoginUIPage
             ""inlines"": [
                 {
                     ""type"": ""TextRun"",
-                    ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_Text")} " + @"""
+                    ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_Text")} " + @"""
                 },
                 {
                     ""type"": ""TextRun"",
-                    ""text"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_HighlightedText")}" + @""",
+                    ""text"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_HighlightedText")}" + @""",
                     ""selectAction"": {
                         ""type"": ""Action.OpenUrl"",
                         ""url"": ""${EnterpriseServerPATPageCreatePATUrlValue}""
@@ -371,7 +366,7 @@ internal class LoginUIPage
         },
         {
             ""type"": ""Input.Text"",
-            ""placeholder"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_InputText_PlaceHolder")}" + @""",
+            ""placeholder"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_InputText_PlaceHolder")}" + @""",
             ""id"": ""PAT"",
             ""spacing"": ""Large"",
             ""value"": ""${EnterpriseServerPATPageInputValue}""
@@ -400,7 +395,7 @@ internal class LoginUIPage
                             ""actions"": [
                                 {
                                     ""type"": ""Action.Submit"",
-                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_Button_Cancel")}" + @""",
+                                    ""title"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_Button_Cancel")}" + @""",
                                     ""id"": ""Cancel"",
                                     ""role"": ""Button""
                                 }
@@ -417,7 +412,7 @@ internal class LoginUIPage
                             ""actions"": [
                                 {
                                     ""type"": ""Action.Submit"",
-                                    ""title"": """ + $"{loader.GetString("LoginUI_EnterprisePATPage_Button_Connect")}" + @""",
+                                    ""title"": """ + $"{Resources.GetResource("LoginUI_EnterprisePATPage_Button_Connect")}" + @""",
                                     ""id"": ""Connect"",
                                     ""style"": ""positive"",
                                     ""role"": ""Button""
@@ -444,7 +439,7 @@ internal class LoginUIPage
     ""body"": [
         {
             ""type"": ""TextBlock"",
-            ""text"": """ + $"{loader.GetString("LoginUI_WaitingPage_Text")}" + @""",
+            ""text"": """ + $"{Resources.GetResource("LoginUI_WaitingPage_Text")}" + @""",
             ""isSubtle"": false,
             ""wrap"": true,
             ""horizontalAlignment"": ""Center"",
@@ -456,7 +451,7 @@ internal class LoginUIPage
         },
         {
             ""type"" : ""TextBlock"",
-            ""text"": """ + $"{loader.GetString("LoginUI_WaitingPageBrowserLaunch_Text")}" + @""",
+            ""text"": """ + $"{Resources.GetResource("LoginUI_WaitingPageBrowserLaunch_Text")}" + @""",
             ""isSubtle"": false,
             ""horizontalAlignment"": ""Center"",
             ""weight"": ""Lighter""
@@ -496,7 +491,7 @@ internal class LoginUIPage
     ""body"": [
         {
             ""type"": ""TextBlock"",
-            ""text"": """ + $"{loader.GetString("LoginUI_LoginFailedPage_text1")}" + @""",
+            ""text"": """ + $"{Resources.GetResource("LoginUI_LoginFailedPage_text1")}" + @""",
             ""isSubtle"": false,
             ""wrap"": true,
             ""horizontalAlignment"": ""Center"",
@@ -507,7 +502,7 @@ internal class LoginUIPage
         },
         {
             ""type"": ""TextBlock"",
-            ""text"": """ + $"{loader.GetString("LoginUI_LoginFailedPage_text2")}" + @""",
+            ""text"": """ + $"{Resources.GetResource("LoginUI_LoginFailedPage_text2")}" + @""",
             ""isSubtle"": true,
             ""wrap"": true,
             ""horizontalAlignment"": ""Center"",
@@ -585,6 +580,16 @@ internal class LoginUIPage
         public string? Type
         {
             get; set;
+        }
+
+        public bool IsCancelAction()
+        {
+            return this.Id == "Cancel";
+        }
+
+        public bool IsUrlAction()
+        {
+            return this.Type == "Action.OpenUrl";
         }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -3,7 +3,6 @@
 
 using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
-using ResourceLoader = Microsoft.Windows.ApplicationModel.Resources.ResourceLoader;
 
 namespace GitHubExtension.DeveloperId;
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;
 
@@ -18,14 +19,7 @@ internal class WaitingPage : LoginUIPage
     {
         public string GetJson()
         {
-            return JsonSerializer.Serialize(
-            this,
-            new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-                IncludeFields = true,
-            });
+            return Json.Stringify(this);
         }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 
 namespace GitHubExtension.DeveloperId.LoginUI;

--- a/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitHubExtension.DeveloperId.LoginUI;
+
+internal class WaitingPage : LoginUIPage
+{
+    public WaitingPage()
+        : base(LoginUIState.WaitingPage)
+    {
+        Data = new WaitingPageData();
+    }
+
+    internal class WaitingPageData : ILoginUIPageData
+    {
+        public string GetJson()
+        {
+            return JsonSerializer.Serialize(
+            this,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                IncludeFields = true,
+            });
+        }
+    }
+}

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -48,7 +48,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
         {
             if (_loginUI == null)
             {
-                Log.Logger()?.ReportError($"_loginUI is null");
+                Log.Logger()?.ReportError($"OnAction() called with invalid state of LoginUI");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, null, "_loginUI is null", "_loginUI is null");
             }
 
@@ -75,7 +75,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
 
                             if (!loginPageActionPayload.IsSubmitAction())
                             {
-                                Log.Logger()?.ReportError($"Invalid action");
+                                Log.Logger()?.ReportError($"Invalid action performed on LoginUI: {loginPageActionPayload.Id}");
                                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action", "Invalid action");
                                 break;
                             }
@@ -119,14 +119,14 @@ public class LoginUIController : IExtensionAdaptiveCardSession
 
                         if (enterprisePageActionPayload.IsCancelAction())
                         {
-                            Log.Logger()?.ReportInfo($"Cancel clicked");
+                            Log.Logger()?.ReportInfo($"Cancel clicked on EnterpriseServerPage");
                             operationResult = new LoginPage().UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
 
                         if (!enterprisePageActionPayload.IsSubmitAction())
                         {
-                            Log.Logger()?.ReportError($"Invalid action");
+                            Log.Logger()?.ReportError($"Invalid action performed on LoginUI: {enterprisePageActionPayload.Id}");
                             operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action", "Invalid action");
                             break;
                         }

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Windows.ApplicationModel.Resources;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
@@ -277,6 +279,238 @@ internal class LoginUIController : IExtensionAdaptiveCardSession
 }
 ";
 
+            var enterpriseServerPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""ColumnSet"",
+            ""spacing"": ""Large"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""items"": [
+                        {
+                            ""type"": ""Image"",
+                            ""style"": ""Person"",
+                            ""url"": ""https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"",
+                            ""size"": ""Small"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""weight"": ""Bolder"",
+                            ""text"": ""GitHub"",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""Small"",
+                            ""size"": ""Large""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": ""Enterprise Server"",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None"",
+                            ""size"": ""Small""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": """",
+                            ""wrap"": true,
+                            ""spacing"": ""Large"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""isSubtle"": true
+                        }
+                    ],
+                    ""width"": ""stretch"",
+                    ""separator"": true,
+                    ""spacing"": ""Medium""
+                }
+            ]
+        },
+        {
+            ""type"": ""Input.Text"",
+            ""placeholder"": ""Enter server address here"",
+            ""id"": ""EnterpriseServer"",
+            ""style"": ""Url"",
+            ""isRequired"": true,
+            ""spacing"": ""ExtraLarge""
+        },
+        {
+            ""type"": ""ColumnSet"",
+            ""horizontalAlignment"": ""Center"",
+            ""height"": ""stretch"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": ""Cancel"",
+                                    ""id"": ""Cancel"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": ""Next"",
+                                    ""id"": ""Next"",
+                                    ""style"": ""positive"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            ""spacing"": ""Small""
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""350px"",
+    ""verticalContentAlignment"": ""Top"",
+    ""rtl"": false
+}
+";
+
+            var enterpriseServerPATPage = @"
+{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+        {
+            ""type"": ""ColumnSet"",
+            ""spacing"": ""Large"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""items"": [
+                        {
+                            ""type"": ""Image"",
+                            ""style"": ""Person"",
+                            ""url"": ""https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"",
+                            ""size"": ""Small"",
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""weight"": ""Bolder"",
+                            ""text"": ""GitHub"",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""Small"",
+                            ""size"": ""Large""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": ""Enterprise Server"",
+                            ""wrap"": true,
+                            ""horizontalAlignment"": ""Center"",
+                            ""spacing"": ""None"",
+                            ""size"": ""Small""
+                        }
+                    ],
+                    ""width"": ""stretch"",
+                    ""separator"": true,
+                    ""spacing"": ""Medium""
+                }
+            ]
+        },
+        {
+            ""type"": ""RichTextBlock"",
+            ""inlines"": [
+                {
+                    ""type"": ""TextRun"",
+                    ""text"": ""Please enter your Personal Access Token (PAT) to connect to <server>. To create a new PAT, ""
+                },
+                {
+                    ""type"": ""TextRun"",
+                    ""text"": ""click here."",
+                    ""selectAction"": {
+                        ""type"": ""Action.OpenUrl"",
+                        ""url"": ""https://adaptivecards.io""
+                    }
+                }
+            ]
+        },
+        {
+            ""type"": ""Input.Text"",
+            ""placeholder"": ""Enter personal access token"",
+            ""id"": ""EnterpriseServer"",
+            ""style"": ""Url"",
+            ""isRequired"": true,
+            ""spacing"": ""Large"",
+            ""errorMessage"": ""Invalid Url""
+        },
+        {
+            ""type"": ""ColumnSet"",
+            ""horizontalAlignment"": ""Center"",
+            ""height"": ""stretch"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": ""Cancel"",
+                                    ""id"": ""Cancel"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""ActionSet"",
+                            ""actions"": [
+                                {
+                                    ""type"": ""Action.Submit"",
+                                    ""title"": ""Connect"",
+                                    ""id"": ""Connect"",
+                                    ""style"": ""positive"",
+                                    ""role"": ""Button""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            ""spacing"": ""Small""
+        }
+    ],
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""version"": ""1.5"",
+    ""minHeight"": ""350px"",
+    ""verticalContentAlignment"": ""Top"",
+    ""rtl"": false
+}
+";
+
             var waitingPage = @"
 {
     ""type"": ""AdaptiveCard"",
@@ -367,6 +601,16 @@ internal class LoginUIController : IExtensionAdaptiveCardSession
                     return loginPage;
                 }
 
+                case LoginUIState.EnterpriseServerPage:
+                {
+                    return enterpriseServerPage;
+                }
+
+                case LoginUIState.EnterpriseServerPATPage:
+                {
+                    return enterpriseServerPATPage;
+                }
+
                 case LoginUIState.WaitingPage:
                 {
                     return waitingPage;
@@ -390,10 +634,38 @@ internal class LoginUIController : IExtensionAdaptiveCardSession
         }
     }
 
+    private class LoginPageActionPayload
+    {
+        public string? Style
+        {
+            get; set;
+        }
+
+        public string? Title
+        {
+            get; set;
+        }
+
+        public string? Type
+        {
+            get; set;
+        }
+    }
+
+    private class LoginPageInputPayload
+    {
+        public string? EnterpriseServer
+        {
+            get; set;
+        }
+    }
+
     // This class cannot be an enum, since we are passing this to the core app as State parameter.
     private class LoginUIState
     {
         internal const string LoginPage = "LoginPage";
+        internal const string EnterpriseServerPage = "EnterpriseServerPage";
+        internal const string EnterpriseServerPATPage = "EnterpriseServerPATPage";
         internal const string WaitingPage = "WaitingPage";
         internal const string LoginFailedPage = "LoginFailedPage";
         internal const string LoginSucceededPage = "LoginSucceededPage";

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license.
 
 using System.Net;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using GitHubExtension.Client;
 using GitHubExtension.DeveloperId.LoginUI;
 using GitHubExtension.Helpers;
@@ -103,7 +101,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
                         catch (Exception ex)
                         {
-                            Log.Logger()?.ReportError($"Error: {ex}");
+                            Log.Logger()?.ReportError($"Error: ", ex);
                             new LoginFailedPage().UpdateExtensionAdaptiveCard(_loginUI);
                             operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, ex, "Error occurred in login page", ex.Message);
                         }
@@ -146,7 +144,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         {
                             // Probe for Enterprise Server instance
                             _hostAddress = new Uri(enterprisePageInputPayload.EnterpriseServer);
-                            if (!Validation.IsReachableGitHubEnterpriseServerURL(_hostAddress))
+                            if (!await Validation.IsReachableGitHubEnterpriseServerURL(_hostAddress))
                             {
                                 operationResult = new EnterpriseServerPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePage_UnreachableErrorText")}").UpdateExtensionAdaptiveCard(_loginUI);
                                 break;
@@ -154,13 +152,13 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
                         catch (UriFormatException ufe)
                         {
-                            Log.Logger()?.ReportError($"Error: {ufe}");
+                            Log.Logger()?.ReportError($"Error: ", ufe);
                             operationResult = new EnterpriseServerPage(hostAddress: enterprisePageInputPayload.EnterpriseServer, errorText: $"{Resources.GetResource("LoginUI_EnterprisePage_UriErrorText")}").UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
                         catch (Exception ex)
                         {
-                            Log.Logger()?.ReportError($"Error: {ex}");
+                            Log.Logger()?.ReportError($"Error: ", ex);
                             operationResult = new EnterpriseServerPage(hostAddress: enterprisePageInputPayload.EnterpriseServer, errorText: $"{Resources.GetResource("LoginUI_EnterprisePage_GenericErrorText")} : {ex}").UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
@@ -171,7 +169,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
                         catch (Exception ex)
                         {
-                            Log.Logger()?.ReportError($"Error: {ex}");
+                            Log.Logger()?.ReportError($"Error: ", ex);
                             operationResult = new LoginFailedPage().UpdateExtensionAdaptiveCard(_loginUI);
                         }
 
@@ -225,13 +223,13 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                             }
                             catch (UriFormatException ufe)
                             {
-                                Log.Logger()?.ReportError($"Error: {ufe}");
+                                Log.Logger()?.ReportError($"Error: ", ufe);
                                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, $"Error: {ufe}", $"Error: {ufe}");
                                 break;
                             }
                             catch (Exception ex)
                             {
-                                Log.Logger()?.ReportError($"Error: {ex}");
+                                Log.Logger()?.ReportError($"Error: ", ex);
                                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, $"Error: {ex}", $"Error: {ex}");
                                 break;
                             }
@@ -282,12 +280,12 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         {
                             if (ex.Message.Contains("Bad credentials") || ex.Message.Contains("Not Found"))
                             {
-                                Log.Logger()?.ReportError($"Unauthorized Error: {ex}");
+                                Log.Logger()?.ReportError($"Unauthorized Error: ", ex);
                                 operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_BadCredentialsErrorText")} {_hostAddress.OriginalString}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                                 break;
                             }
 
-                            Log.Logger()?.ReportError($"Error: {ex}");
+                            Log.Logger()?.ReportError($"Error: ", ex);
                             operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_GenericErrorPrefix")} {ex}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -62,13 +62,13 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         try
                         {
                             // If there is already a developer id, we should block another login.
-                            /*if (_developerIdProvider.GetLoggedInDeveloperIdsInternal().Any())
+                            if (_developerIdProvider.GetLoggedInDeveloperIdsInternal().Any())
                             {
                                 Log.Logger()?.ReportInfo($"DeveloperId {_developerIdProvider.GetLoggedInDeveloperIdsInternal().First().LoginId} already exists. Blocking login.");
                                 new LoginFailedPage().UpdateExtensionAdaptiveCard(_loginUI);
                                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Only one DeveloperId can be logged in at a time", "One DeveloperId already exists");
                                 break;
-                            }*/
+                            }
 
                             var loginPageActionPayload = CreateFromJson<LoginPage.ActionPayload>(action) ?? throw new InvalidOperationException("Invalid action");
 

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -49,7 +49,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
             if (_loginUI == null)
             {
                 Log.Logger()?.ReportError($"OnAction() called with invalid state of LoginUI");
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, null, "_loginUI is null", "_loginUI is null");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, null, "OnAction() called with invalid state of LoginUI", "_loginUI is null");
             }
 
             ProviderOperationResult operationResult;
@@ -76,7 +76,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                             if (!loginPageActionPayload.IsSubmitAction())
                             {
                                 Log.Logger()?.ReportError($"Invalid action performed on LoginUI: {loginPageActionPayload.Id}");
-                                operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action", "Invalid action");
+                                operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action performed on LoginUI", "Invalid action performed on LoginUI");
                                 break;
                             }
 
@@ -127,7 +127,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         if (!enterprisePageActionPayload.IsSubmitAction())
                         {
                             Log.Logger()?.ReportError($"Invalid action performed on LoginUI: {enterprisePageActionPayload.Id}");
-                            operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action", "Invalid action");
+                            operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action performed on LoginUI", "Invalid action");
                             break;
                         }
 
@@ -167,7 +167,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
 
                         try
                         {
-                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: string.Empty, inputPAT: string.Empty).UpdateExtensionAdaptiveCard(_loginUI);
+                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: string.Empty, inputPAT: new NetworkCredential(null, string.Empty).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                         }
                         catch (Exception ex)
                         {
@@ -242,23 +242,25 @@ public class LoginUIController : IExtensionAdaptiveCardSession
 
                         if (!enterprisePATPageActionPayload.IsSubmitAction())
                         {
-                            Log.Logger()?.ReportError($"Invalid action");
-                            operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action", "Invalid action");
+                            Log.Logger()?.ReportError($"Invalid action performed on LoginUI");
+                            operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Invalid action performed on LoginUI", "Invalid action");
                             break;
                         }
 
                         // Otherwise user clicked on Next button. We should validate the inputs and update the UI with PAT page.
                         var enterprisePATPageInputPayload = Json.ToObject<EnterpriseServerPATPage.InputPayload>(inputs) ?? throw new InvalidOperationException("Invalid inputs");
 
-                        if (string.IsNullOrEmpty(enterprisePATPageInputPayload?.PAT))
+                        if (string.IsNullOrEmpty(enterprisePATPageInputPayload.PAT))
                         {
                             Log.Logger()?.ReportError($"PAT is null");
-                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_NullErrorText")}", inputPAT: enterprisePATPageInputPayload?.PAT).UpdateExtensionAdaptiveCard(_loginUI);
+                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_NullErrorText")}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
 
                         Log.Logger()?.ReportInfo($"PAT Received");
-                        var securePAT = new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword;
+                        var securePAT = new NetworkCredential(null, enterprisePATPageInputPayload.PAT).SecurePassword;
+                        enterprisePATPageInputPayload.PAT = string.Empty;
+                        enterprisePATPageInputPayload = null;
 
                         try
                         {
@@ -272,7 +274,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                             else
                             {
                                 Log.Logger()?.ReportError($"PAT doesn't work for GHES endpoint {_hostAddress.OriginalString}");
-                                operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_BadCredentialsErrorText")} {_hostAddress.OriginalString}", inputPAT: enterprisePATPageInputPayload?.PAT).UpdateExtensionAdaptiveCard(_loginUI);
+                                operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_BadCredentialsErrorText")} {_hostAddress.OriginalString}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                                 break;
                             }
                         }
@@ -281,12 +283,12 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                             if (ex.Message.Contains("Bad credentials") || ex.Message.Contains("Not Found"))
                             {
                                 Log.Logger()?.ReportError($"Unauthorized Error: {ex}");
-                                operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_BadCredentialsErrorText")} {_hostAddress.OriginalString}", inputPAT: enterprisePATPageInputPayload?.PAT).UpdateExtensionAdaptiveCard(_loginUI);
+                                operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_BadCredentialsErrorText")} {_hostAddress.OriginalString}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                                 break;
                             }
 
                             Log.Logger()?.ReportError($"Error: {ex}");
-                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_GenericErrorPrefix")} {ex}", inputPAT: enterprisePATPageInputPayload?.PAT).UpdateExtensionAdaptiveCard(_loginUI);
+                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_GenericErrorPrefix")} {ex}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
                     }

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -41,13 +41,22 @@ internal class LoginUIController : IExtensionAdaptiveCardSession
             {
                 case LoginUIState.LoginPage:
                 {
-                    // Inputs are validated at this point.
-                    _loginUI.Update(_loginUITemplate.GetLoginUITemplate(LoginUIState.WaitingPage), null, LoginUIState.WaitingPage);
-                    Log.Logger()?.ReportDebug($"inputs: {inputs}");
-
                     try
                     {
-                        var devId = await (DeveloperIdProvider.GetInstance() as DeveloperIdProvider).LoginNewDeveloperIdAsync();
+                        // If there is already a developer id, we should block another login.
+                        if (DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIdsInternal().Any())
+                        {
+                            Log.Logger()?.ReportInfo($"DeveloperId {DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIdsInternal().First().LoginId} already exists. Blocking login.");
+                            _loginUI.Update(_loginUITemplate.GetLoginUITemplate(LoginUIState.LoginFailedPage), null, LoginUIState.LoginFailedPage);
+                            operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, "Only one DeveloperId can be logged in at a time", "One DeveloperId already exists");
+                            break;
+                        }
+
+                        // Inputs are validated at this point.
+                        _loginUI.Update(_loginUITemplate.GetLoginUITemplate(LoginUIState.WaitingPage), null, LoginUIState.WaitingPage);
+                        Log.Logger()?.ReportDebug($"inputs: {inputs}");
+
+                        var devId = await DeveloperIdProvider.GetInstance().LoginNewDeveloperIdAsync();
                         if (devId != null)
                         {
                             var resourceLoader = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "GitHubExtension/Resources");

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -286,7 +286,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                             }
 
                             Log.Logger()?.ReportError($"Error: {ex}");
-                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_GenericErrorText")} {ex}", inputPAT: enterprisePATPageInputPayload?.PAT).UpdateExtensionAdaptiveCard(_loginUI);
+                            operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_GenericErrorPrefix")} {ex}", inputPAT: enterprisePATPageInputPayload?.PAT).UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
                     }

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -17,6 +17,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
     private IExtensionAdaptiveCard? _loginUI;
     private Uri? _hostAddress;
 
+    // This variable is used to store the host address from EnterpriseServerPage. It is used in EnterpriseServerPATPage.
     public Uri HostAddress
     {
         get => _hostAddress ?? throw new InvalidOperationException("HostAddress is null");
@@ -70,7 +71,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                                 break;
                             }
 
-                            var loginPageActionPayload = CreateFromJson<LoginPage.ActionPayload>(action) ?? throw new InvalidOperationException("Invalid action");
+                            var loginPageActionPayload = Json.ToObject<LoginPage.ActionPayload>(action) ?? throw new InvalidOperationException("Invalid action");
 
                             if (!loginPageActionPayload.IsSubmitAction())
                             {
@@ -113,7 +114,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                 case nameof(LoginUIState.EnterpriseServerPage):
                     {
                         // Check if the user clicked on Cancel button.
-                        var enterprisePageActionPayload = CreateFromJson<EnterpriseServerPage.ActionPayload>(action)
+                        var enterprisePageActionPayload = Json.ToObject<EnterpriseServerPage.ActionPayload>(action)
                                                     ?? throw new InvalidOperationException("Invalid action");
 
                         if (enterprisePageActionPayload.IsCancelAction())
@@ -131,7 +132,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
 
                         // Otherwise user clicked on Next button. We should validate the inputs and update the UI with PAT page.
-                        var enterprisePageInputPayload = CreateFromJson<EnterpriseServerPage.InputPayload>(inputs) ?? throw new InvalidOperationException("Invalid inputs");
+                        var enterprisePageInputPayload = Json.ToObject<EnterpriseServerPage.InputPayload>(inputs) ?? throw new InvalidOperationException("Invalid inputs");
                         Log.Logger()?.ReportInfo($"EnterpriseServer: {enterprisePageInputPayload?.EnterpriseServer}");
 
                         if (enterprisePageInputPayload?.EnterpriseServer == null)
@@ -188,7 +189,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
 
                         // Check if the user clicked on Cancel button.
-                        var enterprisePATPageActionPayload = CreateFromJson<EnterpriseServerPATPage.ActionPayload>(action) ?? throw new InvalidOperationException("Invalid action");
+                        var enterprisePATPageActionPayload = Json.ToObject<EnterpriseServerPATPage.ActionPayload>(action) ?? throw new InvalidOperationException("Invalid action");
 
                         if (enterprisePATPageActionPayload.IsCancelAction())
                         {
@@ -247,7 +248,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
 
                         // Otherwise user clicked on Next button. We should validate the inputs and update the UI with PAT page.
-                        var enterprisePATPageInputPayload = CreateFromJson<EnterpriseServerPATPage.InputPayload>(inputs) ?? throw new InvalidOperationException("Invalid inputs");
+                        var enterprisePATPageInputPayload = Json.ToObject<EnterpriseServerPATPage.InputPayload>(inputs) ?? throw new InvalidOperationException("Invalid inputs");
 
                         if (string.IsNullOrEmpty(enterprisePATPageInputPayload?.PAT))
                         {
@@ -311,15 +312,5 @@ public class LoginUIController : IExtensionAdaptiveCardSession
 
             return operationResult;
         }).AsAsyncOperation();
-    }
-
-    private T? CreateFromJson<T>(string json)
-    {
-        return JsonSerializer.Deserialize<T>(json, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-            IncludeFields = true,
-        });
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -39,11 +39,17 @@ internal class LoginUIController : IExtensionAdaptiveCardSession
     {
         return Task.Run(async () =>
         {
+            if (_loginUI == null)
+            {
+                Log.Logger()?.ReportError($"_loginUI is null");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, null, "_loginUI is null", "_loginUI is null");
+            }
+
             ProviderOperationResult operationResult;
-            Log.Logger()?.ReportInfo($"OnAction() called with state:{_loginUI?.State}");
+            Log.Logger()?.ReportInfo($"OnAction() called with state:{_loginUI.State}");
             Log.Logger()?.ReportDebug($"action: {action}");
 
-            switch (_loginUI?.State)
+            switch (_loginUI.State)
             {
                 case LoginUIState.LoginPage:
                 {
@@ -179,6 +185,8 @@ internal class LoginUIController : IExtensionAdaptiveCardSession
                     if (enterprisePATPageActionPayload?.Id == "Cancel")
                     {
                         Log.Logger()?.ReportInfo($"Cancel clicked");
+
+                        // TODO: Replace Hostaddress in template with the one entered by user in Enterprise page already
                         operationResult = _loginUI.Update(_loginUITemplate.GetLoginUITemplate(LoginUIState.EnterpriseServerPage), null, LoginUIState.EnterpriseServerPage);
                         break;
                     }
@@ -251,8 +259,8 @@ internal class LoginUIController : IExtensionAdaptiveCardSession
                 case LoginUIState.WaitingPage:
                 default:
                 {
-                    Log.Logger()?.ReportError($"Unexpected state:{_loginUI?.State}");
-                    operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, $"Error occurred in :{_loginUI?.State}", $"Error occurred in :{_loginUI?.State}");
+                    Log.Logger()?.ReportError($"Unexpected state:{_loginUI.State}");
+                    operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, $"Error occurred in :{_loginUI.State}", $"Error occurred in :{_loginUI.State}");
                     break;
                 }
             }

--- a/src/GitHubExtension/DeveloperId/OAuthRequest.cs
+++ b/src/GitHubExtension/DeveloperId/OAuthRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Collections.Specialized;
 using System.Net;
 using System.Security;
 using System.Security.Cryptography;

--- a/src/GitHubExtension/DeveloperId/OAuthRequest.cs
+++ b/src/GitHubExtension/DeveloperId/OAuthRequest.cs
@@ -53,7 +53,7 @@ internal class OAuthRequest : IDisposable
 
         var request = new OauthLoginRequest(OauthConfiguration.GetClientId())
         {
-            Scopes = { "user", "notifications", "repo", "read:org" },
+            Scopes = { "read:user", "notifications", "repo", "read:org" },
             State = State,
             RedirectUri = new Uri(OauthConfiguration.RedirectUri),
         };

--- a/src/GitHubExtension/Helpers/Json.cs
+++ b/src/GitHubExtension/Helpers/Json.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace GitHubExtension.Helpers;
@@ -30,6 +32,38 @@ public static class Json
         return await Task.Run<string>(() =>
         {
             return JsonConvert.SerializeObject(value);
+        });
+    }
+
+    public static string Stringify<T>(T value)
+    {
+        if (typeof(T) == typeof(bool))
+        {
+            return value!.ToString()!.ToLowerInvariant();
+        }
+
+        return System.Text.Json.JsonSerializer.Serialize(
+            value,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                IncludeFields = true,
+            });
+    }
+
+    public static T? ToObject<T>(string json)
+    {
+        if (typeof(T) == typeof(bool))
+        {
+            return (T)(object)bool.Parse(json);
+        }
+
+        return System.Text.Json.JsonSerializer.Deserialize<T>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            IncludeFields = true,
         });
     }
 }

--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -205,12 +205,20 @@ public class RepositoryProvider : IRepositoryProvider
             {
                 var loggedInDeveloperId = DeveloperId.DeveloperIdProvider.GetInstance().GetDeveloperIdInternal(developerId);
 
-                cloneOptions.CredentialsProvider = (url, user, cred) => new LibGit2Sharp.UsernamePasswordCredentials
+                try
                 {
-                    // Password is a PAT unique to GitHub.
-                    Username = loggedInDeveloperId.GetCredential().Password,
-                    Password = string.Empty,
-                };
+                    cloneOptions.CredentialsProvider = (url, user, cred) => new LibGit2Sharp.UsernamePasswordCredentials
+                    {
+                        // Password is a PAT unique to GitHub.
+                        Username = loggedInDeveloperId.GetCredential().Password,
+                        Password = string.Empty,
+                    };
+                }
+                catch (Exception e)
+                {
+                    Log.Logger()?.ReportError("DevHomeRepository", "Could not get credentials.", e);
+                    return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Could not get credentials.", e.Message);
+                }
             }
 
             try

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -215,7 +215,7 @@
   </data>
   <data name="LoginUI_LoginPage_Button1Text" xml:space="preserve">
     <value>Sign in to github.com</value>
-    <comment>Button name to login to GitHub.com</comment>
+    <comment>Button name to login to GitHub.com. "github.com" should not be localized.</comment>
   </data>
   <data name="LoginUI_LoginPage_Button1ToolTip" xml:space="preserve">
     <value>Opens the browser to log you into GitHub</value>

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -225,21 +225,23 @@
     <value>Go</value>
   </data>
   <data name="LoginUI_LoginPage_Button2Flyout_Text_ErrorMessage" xml:space="preserve">
-    <value>Please enter a valid GitHub enterprise server URL</value>
+    <value>Please enter a valid GitHub Enterprise Server URL</value>
+    <comment>"GitHub Enterprise Server" should not be localized</comment>
   </data>
   <data name="LoginUI_LoginPage_Button2Flyout_Text_Label" xml:space="preserve">
     <value>Server URL</value>
   </data>
   <data name="LoginUI_LoginPage_Button2Flyout_Text_PlaceHolder" xml:space="preserve">
-    <value>&lt;Enter the GitHub Server link&gt;</value>
+    <value>&lt;Enter the GitHub Enterprise Server link&gt;</value>
+    <comment>"GitHub Enterprise Server" should not be localized</comment>
   </data>
   <data name="LoginUI_LoginPage_Button2Text" xml:space="preserve">
     <value>Sign in to GitHub Enterprise Server</value>
-    <comment>Button name to login to GHES</comment>
+    <comment>Button name to login to GitHub Enterprise Server</comment>
   </data>
   <data name="LoginUI_LoginPage_Button2ToolTip" xml:space="preserve">
     <value>Lets you enter the host address of your GitHub Enterprise Server</value>
-    <comment>Tooltip text on mouse hover over GHES button</comment>
+    <comment>Tooltip text on mouse hover over GitHub Enterprise Server button</comment>
   </data>
   <data name="LoginUI_LoginPage_Heading" xml:space="preserve">
     <value>GitHub</value>
@@ -250,8 +252,8 @@
     <comment>Page subtitle</comment>
   </data>
   <data name="LoginUI_LoginSucceededPage_text" xml:space="preserve">
-    <value>has logged in successfully! You may close this window.</value>
-    <comment>Partial text for when a user signs in successfully</comment>
+    <value>{User} has logged in successfully! You may close this window.</value>
+    <comment>Text for when a user signs in successfully</comment>
   </data>
   <data name="LoginUI_WaitingPage_Text" xml:space="preserve">
     <value>Waiting for browser...</value>
@@ -437,7 +439,7 @@
   </data>
   <data name="LoginUI_EnterprisePage_NullErrorText" xml:space="preserve">
     <value>Enterprise Server is not valid</value>
-    <comment>LoginUI Error text</comment>
+    <comment>LoginUI Error text if input is not valid</comment>
   </data>
   <data name="LoginUI_EnterprisePage_Heading" xml:space="preserve">
     <value>GitHub</value>
@@ -445,7 +447,7 @@
   </data>
   <data name="LoginUI_EnterprisePage_InputText_PlaceHolder" xml:space="preserve">
     <value>Enter server address here</value>
-    <comment>LoginUI placeholder text</comment>
+    <comment>LoginUI Input placeholder text</comment>
   </data>
   <data name="LoginUI_EnterprisePage_Subheading" xml:space="preserve">
     <value>Enterprise Server</value>
@@ -461,38 +463,42 @@
   </data>
   <data name="LoginUI_EnterprisePage_UriErrorText" xml:space="preserve">
     <value>URL is invalid</value>
-    <comment>LoginUI Error text</comment>
+    <comment>LoginUI Error text if input is not a valid URL</comment>
   </data>
   <data name="LoginUI_EnterprisePage_UnreachableErrorText" xml:space="preserve">
     <value>Enterprise Server is not reachable</value>
-    <comment>LoginUI Error text</comment>
-  </data>
-  <data name="LoginUI_EnterprisePATPage_HighlightedText" xml:space="preserve">
-    <value>click here.</value>
-    <comment>LoginUI Instructional text with hyperlink</comment>
+    <comment>LoginUI Error text if input is not reachable</comment>
   </data>
   <data name="LoginUI_EnterprisePATPage_InputText_PlaceHolder" xml:space="preserve">
-    <value>Enter personal access token</value>
+    <value>Enter Personal Access Token</value>
     <comment>LoginUI placeholder text</comment>
   </data>
-  <data name="LoginUI_EnterprisePATPage_Text" xml:space="preserve">
-    <value>Enter your Personal Access Token (PAT) to connect to ${EnterpriseServerPATPageServerUrlValue}. To create a new PAT,</value>
-    <comment>LoginUI Instructional text</comment>
+  <data name="LoginUI_EnterprisePATPage_Text1" xml:space="preserve">
+    <value>Enter your Personal Access Token (PAT) to connect to ${EnterpriseServerPATPageServerUrlValue}. To create a new PAT, </value>
+    <comment>LoginUI Instructional text before highlighted text. This will be displayed as "LoginUI_EnterprisePATPage_Text1+LoginUI_EnterprisePATPage_HighlightedText+LoginUI_EnterprisePATPage_Text2".</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_HighlightedText" xml:space="preserve">
+    <value>click here</value>
+    <comment>LoginUI Instructional text with hyperlink. This will be displayed as "LoginUI_EnterprisePATPage_Text1+LoginUI_EnterprisePATPage_HighlightedText+LoginUI_EnterprisePATPage_Text2".</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_Text2" xml:space="preserve">
+    <value>.</value>
+    <comment>LoginUI Instructional text after highlighted text. In some languages, there might be some text after the highlighted text with link. This will be displayed as "LoginUI_EnterprisePATPage_Text1+LoginUI_EnterprisePATPage_HighlightedText+LoginUI_EnterprisePATPage_Text2".</comment>
   </data>
   <data name="LoginUI_EnterprisePage_GenericErrorText" xml:space="preserve">
     <value>Something went wrong</value>
-    <comment>LoginUI Error text</comment>
+    <comment>LoginUI Error text for generic case</comment>
   </data>
   <data name="LoginUI_EnterprisePATPage_BadCredentialsErrorText" xml:space="preserve">
-    <value>PAT doesn't work for GHES endpoint</value>
-    <comment>LoginUI Error text</comment>
+    <value>PAT doesn't work for this GitHub Enterprise Server endpoint</value>
+    <comment>LoginUI Error text if input Personal Access Token does not work; "GitHub Enterprise Server" should not be localized</comment>
   </data>
-  <data name="LoginUI_EnterprisePATPage_GenericErrorText" xml:space="preserve">
+  <data name="LoginUI_EnterprisePATPage_GenericErrorPrefix" xml:space="preserve">
     <value>Error:</value>
-    <comment>LoginUI Error text</comment>
+    <comment>LoginUI Error Prefix</comment>
   </data>
   <data name="LoginUI_EnterprisePATPage_NullErrorText" xml:space="preserve">
     <value>Please enter the PAT</value>
-    <comment>LoginUI Error text</comment>
+    <comment>LoginUI Error text if input is null</comment>
   </data>
 </root>

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -435,7 +435,7 @@
     <value>Next</value>
     <comment>LoginUI Button text</comment>
   </data>
-  <data name="LoginUI_EnterprisePage_ErrorText" xml:space="preserve">
+  <data name="LoginUI_EnterprisePage_NullErrorText" xml:space="preserve">
     <value>Enterprise Server is not valid</value>
     <comment>LoginUI Error text</comment>
   </data>
@@ -459,9 +459,13 @@
     <value>Connect</value>
     <comment>LoginUI Button text</comment>
   </data>
-  <data name="LoginUI_EnterprisePATPage_ErrorText" xml:space="preserve">
-    <value>Unable to connect to the Enterprise Server</value>
-    <comment>LoginUI Button text</comment>
+  <data name="LoginUI_EnterprisePage_UriErrorText" xml:space="preserve">
+    <value>URL is invalid</value>
+    <comment>LoginUI Error text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_UnreachableErrorText" xml:space="preserve">
+    <value>Enterprise Server is not reachable</value>
+    <comment>LoginUI Error text</comment>
   </data>
   <data name="LoginUI_EnterprisePATPage_HighlightedText" xml:space="preserve">
     <value>click here.</value>
@@ -474,5 +478,21 @@
   <data name="LoginUI_EnterprisePATPage_Text" xml:space="preserve">
     <value>Enter your Personal Access Token (PAT) to connect to ${EnterpriseServerPATPageServerUrlValue}. To create a new PAT,</value>
     <comment>LoginUI Instructional text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_GenericErrorText" xml:space="preserve">
+    <value>Something went wrong</value>
+    <comment>LoginUI Error text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_BadCredentialsErrorText" xml:space="preserve">
+    <value>PAT doesn't work for GHES endpoint</value>
+    <comment>LoginUI Error text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_GenericErrorText" xml:space="preserve">
+    <value>Error:</value>
+    <comment>LoginUI Error text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_NullErrorText" xml:space="preserve">
+    <value>Please enter the PAT</value>
+    <comment>LoginUI Error text</comment>
   </data>
 </root>

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -207,15 +207,19 @@
   </data>
   <data name="LoginUI_LoginFailedPage_text1" xml:space="preserve">
     <value>Something went wrong :(</value>
+    <comment>Generic error text shown in LoginUI failure page</comment>
   </data>
   <data name="LoginUI_LoginFailedPage_text2" xml:space="preserve">
     <value>Please consider filing feedback</value>
+    <comment>Generic error text shown in LoginUI failure page</comment>
   </data>
   <data name="LoginUI_LoginPage_Button1Text" xml:space="preserve">
     <value>Sign in to github.com</value>
+    <comment>Button name to login to GitHub.com</comment>
   </data>
   <data name="LoginUI_LoginPage_Button1ToolTip" xml:space="preserve">
     <value>Opens the browser to log you into GitHub</value>
+    <comment>Tooltip text on mouse hover over login button</comment>
   </data>
   <data name="LoginUI_LoginPage_Button2Flyout_Button" xml:space="preserve">
     <value>Go</value>
@@ -230,22 +234,28 @@
     <value>&lt;Enter the GitHub Server link&gt;</value>
   </data>
   <data name="LoginUI_LoginPage_Button2Text" xml:space="preserve">
-    <value>Sign in to GitHub Enterprise (Coming Soon!)</value>
+    <value>Sign in to GitHub Enterprise Server</value>
+    <comment>Button name to login to GHES</comment>
   </data>
   <data name="LoginUI_LoginPage_Button2ToolTip" xml:space="preserve">
-    <value>Coming soon!</value>
+    <value>Lets you enter the host address of your GitHub Enterprise Server</value>
+    <comment>Tooltip text on mouse hover over GHES button</comment>
   </data>
   <data name="LoginUI_LoginPage_Heading" xml:space="preserve">
     <value>GitHub</value>
+    <comment>Page title</comment>
   </data>
   <data name="LoginUI_LoginPage_Subheading" xml:space="preserve">
     <value>Sign in</value>
+    <comment>Page subtitle</comment>
   </data>
   <data name="LoginUI_LoginSucceededPage_text" xml:space="preserve">
     <value>has logged in successfully! You may close this window.</value>
+    <comment>Partial text for when a user signs in successfully</comment>
   </data>
   <data name="LoginUI_WaitingPage_Text" xml:space="preserve">
     <value>Waiting for browser...</value>
+    <comment>Shown in Waiting page</comment>
   </data>
   <data name="Widget_Template.SignInRequired" xml:space="preserve">
     <value>Sign in to use this widget.</value>
@@ -365,6 +375,7 @@
   </data>
   <data name="LoginUI_WaitingPageBrowserLaunch_Text" xml:space="preserve">
     <value>Note: Browser may have launched in the background.</value>
+    <comment>Shown in Waiting page</comment>
   </data>
   <data name="WidgetTemplate_UnknownTime" xml:space="preserve">
     <value>not known</value>
@@ -415,5 +426,53 @@
   <data name="Widget_Template_Tooltip.Cancel" xml:space="preserve">
     <value>Cancel</value>
     <comment>Shown in Widget, Button tooltip</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_Button_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>LoginUI Button text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_Button_Next" xml:space="preserve">
+    <value>Next</value>
+    <comment>LoginUI Button text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_ErrorText" xml:space="preserve">
+    <value>Enterprise Server is not valid</value>
+    <comment>LoginUI Error text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_Heading" xml:space="preserve">
+    <value>GitHub</value>
+    <comment>LoginUI Page Title</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_InputText_PlaceHolder" xml:space="preserve">
+    <value>Enter server address here</value>
+    <comment>LoginUI placeholder text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePage_Subheading" xml:space="preserve">
+    <value>Enterprise Server</value>
+    <comment>LoginUI Page subtitle</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_Button_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>LoginUI Button text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_Button_Connect" xml:space="preserve">
+    <value>Connect</value>
+    <comment>LoginUI Button text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_ErrorText" xml:space="preserve">
+    <value>Unable to connect to the Enterprise Server</value>
+    <comment>LoginUI Button text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_HighlightedText" xml:space="preserve">
+    <value>click here.</value>
+    <comment>LoginUI Instructional text with hyperlink</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_InputText_PlaceHolder" xml:space="preserve">
+    <value>Enter personal access token</value>
+    <comment>LoginUI placeholder text</comment>
+  </data>
+  <data name="LoginUI_EnterprisePATPage_Text" xml:space="preserve">
+    <value>Enter your Personal Access Token (PAT) to connect to ${EnterpriseServerPATPageServerUrlValue}. To create a new PAT,</value>
+    <comment>LoginUI Instructional text</comment>
   </data>
 </root>

--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
 using GitHubExtension.Widgets.Enums;

--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -129,7 +129,7 @@ internal class GitHubReviewWidget : GitHubWidget
                 UsePublicClientAsFallback = true,
             };
 
-            SearchIssuesRequest request = new SearchIssuesRequest($"review-requested:{ReferredName}");
+            var request = new SearchIssuesRequest($"review-requested:{ReferredName}");
             var searchManager = GitHubSearchManager.CreateInstance();
             searchManager?.SearchForGitHubIssuesOrPRs(request, Name, SearchCategory.PullRequests, requestOptions);
             Log.Logger()?.ReportInfo(Name, ShortId, $"Requested search for {referredName}");

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -245,11 +245,8 @@ public abstract class GitHubWidget : WidgetImpl
             try
             {
                 // Get client for logged in user.
-                var client = GitHubClientProvider.Instance.GetClientForLoggedInDeveloper(true).Result;
-                if (client == null)
-                {
+                var client = GitHubClientProvider.Instance.GetClientForLoggedInDeveloper(true).Result ??
                     throw new InvalidOperationException("Failed getting GitHubClient.");
-                }
 
                 // Get repository for the URL, which is "data" in this case.
                 var ownerName = Validation.ParseOwnerFromGitHubURL(data);

--- a/src/GitHubExtensionServer/Package.appxmanifest
+++ b/src/GitHubExtensionServer/Package.appxmanifest
@@ -3,7 +3,7 @@
   <Extensions>
     <Extension Category="windows.activatableClass.proxyStub">
       <ProxyStub ClassId="00000355-0000-0000-C000-000000000046">
-        <Path>Microsoft.Windows.Widgets.winmd</Path>
+        <Path>Microsoft.Windows.Widgets.Providers.Projection.dll</Path>
         <Interface Name="Microsoft.Windows.Widgets.Providers.IWidgetProvider" InterfaceId="5C5774CC-72A0-452D-B9ED-075C0DD25EED" />
         <Interface Name="Microsoft.Windows.Widgets.Providers.IWidgetProvider2" InterfaceId="38C3A963-DD93-479D-9276-04BF84EE1816" />
       </ProxyStub>

--- a/src/Logging/listeners/ListenerBase.cs
+++ b/src/Logging/listeners/ListenerBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using DevHome.Logging;
-
 namespace DevHome.Logging.Listeners;
 
 public abstract class ListenerBase : IListener

--- a/src/Telemetry/ILogger.cs
+++ b/src/Telemetry/ILogger.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GitHubExtension.Telemetry;
 

--- a/src/Telemetry/LogLevel.cs
+++ b/src/Telemetry/LogLevel.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace GitHubExtension.Telemetry;
 
 /// <summary>

--- a/src/Telemetry/Logger.cs
+++ b/src/Telemetry/Logger.cs
@@ -3,17 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Input;
 using Microsoft.Diagnostics.Telemetry;
-using Microsoft.Win32;
 
 namespace GitHubExtension.Telemetry;
 

--- a/src/Telemetry/LoggerFactory.cs
+++ b/src/Telemetry/LoggerFactory.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace GitHubExtension.Telemetry;
 
 /// <summary>

--- a/test/Console/Program.cs
+++ b/test/Console/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using GitHubExtension;
-using GitHubExtension.DataModel;
 
 internal class Program
 {

--- a/test/GitHubExtension/DeveloperId/CredentialVaultTests.cs
+++ b/test/GitHubExtension/DeveloperId/CredentialVaultTests.cs
@@ -13,13 +13,13 @@ public partial class DeveloperIdTests
     [TestCategory("Unit")]
     public void CredentialVault_CreateSingleton()
     {
-        var credentialVault1 = CredentialVault.GetInstance();
+        var credentialVault1 = new CredentialVault("DevHomeGitHubExtensionTest");
         Assert.IsNotNull(credentialVault1);
 
-        var credentialVault2 = CredentialVault.GetInstance();
+        var credentialVault2 = new CredentialVault("DevHomeGitHubExtensionTest");
         Assert.IsNotNull(credentialVault2);
 
-        Assert.AreEqual(credentialVault1, credentialVault2);
+        Assert.AreNotEqual(credentialVault1, credentialVault2);
 
         credentialVault1.RemoveAllCredentials();
         Assert.AreEqual(0, credentialVault1.GetAllCredentials().Count());
@@ -32,7 +32,7 @@ public partial class DeveloperIdTests
     [DataRow("https://RandomWebServer.example/testuser3")]
     public void CredentialVault_SaveAndRetrieveCredential(string loginId)
     {
-        var credentialVault = CredentialVault.GetInstance();
+        var credentialVault = new CredentialVault("DevHomeGitHubExtensionTest");
         Assert.IsNotNull(credentialVault);
         Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
 
@@ -59,7 +59,7 @@ public partial class DeveloperIdTests
     [DataRow("https://RandomWebServer.example/testuser3")]
     public void CredentialVault_RemoveAndRetrieveCredential(string loginId)
     {
-        var credentialVault = CredentialVault.GetInstance();
+        var credentialVault = new CredentialVault("DevHomeGitHubExtensionTest");
         Assert.IsNotNull(credentialVault);
 
         var testPassword = "testpassword";
@@ -83,7 +83,7 @@ public partial class DeveloperIdTests
     [TestCategory("Unit")]
     public void CredentialVault_GetAllCredentials()
     {
-        var credentialVault = CredentialVault.GetInstance();
+        var credentialVault = new CredentialVault("DevHomeGitHubExtensionTest");
         Assert.IsNotNull(credentialVault);
 
         Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());

--- a/test/GitHubExtension/DeveloperId/CredentialVaultTests.cs
+++ b/test/GitHubExtension/DeveloperId/CredentialVaultTests.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Net;
+using GitHubExtension.DeveloperId;
+
+namespace GitHubExtension.Test;
+
+// Unit Tests for CredentialVault
+public partial class DeveloperIdTests
+{
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CredentialVault_CreateSingleton()
+    {
+        var credentialVault1 = CredentialVault.GetInstance();
+        Assert.IsNotNull(credentialVault1);
+
+        var credentialVault2 = CredentialVault.GetInstance();
+        Assert.IsNotNull(credentialVault2);
+
+        Assert.AreEqual(credentialVault1, credentialVault2);
+
+        credentialVault1.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault1.GetAllCredentials().Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    [DataRow("testuser1")]
+    [DataRow("https://github.com/testuser2")]
+    [DataRow("https://RandomWebServer.example/testuser3")]
+    public void CredentialVault_SaveAndRetrieveCredential(string loginId)
+    {
+        var credentialVault = CredentialVault.GetInstance();
+        Assert.IsNotNull(credentialVault);
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+
+        var nullPassword = credentialVault.GetCredentials(loginId);
+        Assert.IsNull(nullPassword);
+
+        var testPassword = "testpassword";
+
+        var password = new NetworkCredential(null, testPassword).SecurePassword;
+        credentialVault.SaveCredentials(loginId, password);
+
+        var retrievedPassword = credentialVault.GetCredentials(loginId);
+        Assert.IsNotNull(retrievedPassword);
+        Assert.AreEqual(testPassword, retrievedPassword.Password);
+
+        credentialVault.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    [DataRow("testuser1")]
+    [DataRow("https://github.com/testuser2")]
+    [DataRow("https://RandomWebServer.example/testuser3")]
+    public void CredentialVault_RemoveAndRetrieveCredential(string loginId)
+    {
+        var credentialVault = CredentialVault.GetInstance();
+        Assert.IsNotNull(credentialVault);
+
+        var testPassword = "testpassword";
+
+        var password = new NetworkCredential(null, testPassword).SecurePassword;
+        credentialVault.SaveCredentials(loginId, password);
+
+        var retrievedPassword = credentialVault.GetCredentials(loginId);
+        Assert.IsNotNull(retrievedPassword);
+        Assert.AreEqual(testPassword, retrievedPassword.Password);
+
+        credentialVault.RemoveCredentials(loginId);
+
+        var nullPassword = credentialVault.GetCredentials(loginId);
+        Assert.IsNull(nullPassword);
+
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CredentialVault_GetAllCredentials()
+    {
+        var credentialVault = CredentialVault.GetInstance();
+        Assert.IsNotNull(credentialVault);
+
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+
+        var testLoginId = "testuser1";
+        var testPassword = "testpassword";
+
+        var password = new NetworkCredential(null, testPassword).SecurePassword;
+        credentialVault.SaveCredentials(testLoginId, password);
+
+        Assert.AreEqual(1, credentialVault.GetAllCredentials().Count());
+
+        credentialVault.RemoveCredentials(testLoginId);
+
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+
+        var nullPassword = credentialVault.GetCredentials(testLoginId);
+        Assert.IsNull(nullPassword);
+    }
+}

--- a/test/GitHubExtension/DeveloperId/CredentialVaultTests.cs
+++ b/test/GitHubExtension/DeveloperId/CredentialVaultTests.cs
@@ -26,7 +26,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     [DataRow("testuser1")]
     [DataRow("https://github.com/testuser2")]
     [DataRow("https://RandomWebServer.example/testuser3")]
@@ -53,7 +53,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     [DataRow("testuser1")]
     [DataRow("https://github.com/testuser2")]
     [DataRow("https://RandomWebServer.example/testuser3")]
@@ -80,7 +80,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     public void CredentialVault_GetAllCredentials()
     {
         var credentialVault = new CredentialVault("DevHomeGitHubExtensionTest");

--- a/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -14,6 +14,9 @@ public partial class DeveloperIdTests
         Assert.IsNotNull(credentialVault);
         credentialVault.RemoveAllCredentials();
         Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+
+        // Ensure that the DeveloperIdProvider is deleted and recreated on the next GetInstance() call
+        DeveloperIdProvider.GetInstance().Dispose();
         return credentialVault;
     }
 
@@ -104,7 +107,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     public void DeveloperIdProvider_RestoreAndGetDeveloperIds()
     {
         // Setup CredentialVault with a dummy testuser and valid PAT for Github.com
@@ -213,7 +216,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     public void DeveloperIdProvider_LogoutDeveloperId_Success()
     {
         // Setup CredentialVault with a dummy testuser and valid PAT for Github.com
@@ -240,7 +243,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     public void DeveloperIdProvider_LogoutDeveloperId_GHES_Success()
     {
         // Setup CredentialVault with a dummy testuser and valid PAT for Github Enterprise Server

--- a/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -16,7 +16,7 @@ public partial class DeveloperIdTests
         Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
 
         // Ensure that the DeveloperIdProvider is deleted and recreated on the next GetInstance() call
-        DeveloperIdProvider.GetInstance().Dispose();
+        DeveloperIdProvider.ResetInstanceForTests();
         return credentialVault;
     }
 

--- a/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -1,0 +1,268 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Net;
+using GitHubExtension.DeveloperId;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace GitHubExtension.Test;
+public partial class DeveloperIdTests
+{
+    private CredentialVault SetupCleanCredentialVaultClean()
+    {
+        var credentialVault = new CredentialVault();
+        Assert.IsNotNull(credentialVault);
+        credentialVault.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+        return credentialVault;
+    }
+
+    /* Tests depend on the following environment variables:
+     * DEV_HOME_TEST_GITHUB_COM_USER : Url for a test user on github.com
+     * DEV_HOME_TEST_GITHUB_COM_PAT : Personal Access Token for the test user on github.com
+     */
+    private CredentialVault SetupCredentialVaultWithTestUser()
+    {
+        var credentialVault = SetupCleanCredentialVaultClean();
+
+        var testLoginId = Environment.GetEnvironmentVariable("DEV_HOME_TEST_GITHUB_COM_USER") ?? string.Empty;
+        var testPassword = Environment.GetEnvironmentVariable("DEV_HOME_TEST_GITHUB_COM_PAT");
+
+        var password = new NetworkCredential(null, testPassword).SecurePassword;
+        credentialVault.SaveCredentials(testLoginId, password);
+
+        Assert.AreEqual(1, credentialVault.GetAllCredentials().Count());
+        return credentialVault;
+    }
+
+    /* Tests depend on the following environment variables:
+     * DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER_USER : Url for a test user on GHES
+     * DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER_PAT : Personal Access Token for the test user on the GHES
+     */
+    private CredentialVault SetupCredentialVaultWithGHESTestUser()
+    {
+        var credentialVault = SetupCleanCredentialVaultClean();
+
+        var testLoginId = Environment.GetEnvironmentVariable("DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER_USER") ?? string.Empty;
+        var testPassword = Environment.GetEnvironmentVariable("DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER_PAT");
+
+        var password = new NetworkCredential(null, testPassword).SecurePassword;
+        credentialVault.SaveCredentials(testLoginId, password);
+
+        Assert.AreEqual(1, credentialVault.GetAllCredentials().Count());
+        return credentialVault;
+    }
+
+    private CredentialVault SetupCredentialVaultWithInvalidTestUser()
+    {
+        var credentialVault = SetupCleanCredentialVaultClean();
+
+        var testLoginId = "dummytestuser1";
+        var testPassword = "invalidPAT";
+
+        var password = new NetworkCredential(null, testPassword).SecurePassword;
+        credentialVault.SaveCredentials(testLoginId, password);
+
+        Assert.AreEqual(1, credentialVault.GetAllCredentials().Count());
+        return credentialVault;
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_SingletonTest()
+    {
+        // Ensure that the DeveloperIdProvider is a singleton
+        var devIdProvider1 = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider1);
+        Assert.IsInstanceOfType(devIdProvider1, typeof(DeveloperIdProvider));
+
+        var devIdProvider2 = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider2);
+        Assert.IsInstanceOfType(devIdProvider2, typeof(DeveloperIdProvider));
+
+        Assert.AreSame(devIdProvider1, devIdProvider2);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetDeveloperIds_Empty()
+    {
+        // Remove any existing credentials
+        var credentialVault = SetupCleanCredentialVaultClean();
+
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+
+        var result = devIdProvider.GetLoggedInDeveloperIds();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+        Assert.AreEqual(0, result.DeveloperIds.Count());
+
+        // Cleanup
+        credentialVault.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_RestoreAndGetDeveloperIds()
+    {
+        // Setup CredentialVault with a dummy testuser and valid PAT for Github.com
+        var credentialVault = SetupCredentialVaultWithTestUser();
+
+        // Test whether the DeveloperIdProvider can restore the saved credentials
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+        var result = devIdProvider.GetLoggedInDeveloperIds();
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+        Assert.AreEqual(1, result.DeveloperIds.Count());
+        Assert.AreNotEqual("dummytestuser1", result.DeveloperIds.First().LoginId);
+        Assert.IsNotNull(new Uri(result.DeveloperIds.First().Url));
+
+        // Cleanup
+        credentialVault.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetDeveloperIds_InvalidPAT()
+    {
+        // Setup CredentialVault with a dummy testuser and invalid PAT for Github.com
+        var credentialVault = SetupCredentialVaultWithInvalidTestUser();
+
+        // Test whether the DeveloperIdProvider can restore the saved credentials
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+        var result = devIdProvider.GetLoggedInDeveloperIds();
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+        Assert.AreEqual(0, result.DeveloperIds.Count());
+
+        // Cleanup
+        credentialVault.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_AuthenticationExperienceKind()
+    {
+           var devIdProvider = DeveloperIdProvider.GetInstance();
+           Assert.IsNotNull(devIdProvider);
+           Assert.AreEqual(AuthenticationExperienceKind.CardSession, devIdProvider.GetAuthenticationExperienceKind());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetLoginAdaptiveCardSession()
+    {
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+        var result = devIdProvider.GetLoginAdaptiveCardSession();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+        Assert.IsNotNull(result.AdaptiveCardSession);
+        Assert.IsInstanceOfType(result.AdaptiveCardSession, typeof(IExtensionAdaptiveCardSession));
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_ShowLogonSession_NeverImplemented()
+    {
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+        DeveloperIdResult? result = null;
+        try
+        {
+            result = devIdProvider.ShowLogonSession(default(Microsoft.UI.WindowId)).GetResults();
+        }
+        catch (Exception e)
+        {
+            Assert.IsInstanceOfType(e, typeof(NotImplementedException));
+        }
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_GetDeveloperIdState_NeverImplemented()
+    {
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+
+        var result = devIdProvider.GetDeveloperIdState(new DeveloperId.DeveloperId());
+        Assert.IsNotNull(result);
+        Assert.AreEqual(AuthenticationState.LoggedOut, result);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_LogoutDeveloperId_InvalidDeveloperId()
+    {
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+
+        var result = devIdProvider.LogoutDeveloperId(new DeveloperId.DeveloperId());
+        Assert.IsNotNull(result);
+        Assert.AreEqual(ProviderOperationStatus.Failure, result.Status);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_LogoutDeveloperId_Success()
+    {
+        // Setup CredentialVault with a dummy testuser and valid PAT for Github.com
+        var credentialVault = SetupCredentialVaultWithTestUser();
+
+        // Test whether the DeveloperIdProvider can restore the saved credentials
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+        var resultGetLoggedInDeveloperIds = devIdProvider.GetLoggedInDeveloperIds();
+
+        Assert.IsNotNull(resultGetLoggedInDeveloperIds);
+        Assert.AreEqual(ProviderOperationStatus.Success, resultGetLoggedInDeveloperIds.Result.Status);
+        Assert.AreEqual(1, resultGetLoggedInDeveloperIds.DeveloperIds.Count());
+        var devId = resultGetLoggedInDeveloperIds.DeveloperIds.First();
+        Assert.IsNotNull(devId);
+
+        var resultLogoutDeveloperId = devIdProvider.LogoutDeveloperId(devId);
+        Assert.IsNotNull(resultLogoutDeveloperId);
+        Assert.AreEqual(ProviderOperationStatus.Success, resultLogoutDeveloperId.Status);
+        Assert.AreEqual(AuthenticationState.LoggedOut, devIdProvider.GetDeveloperIdState(devId));
+
+        credentialVault.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DeveloperIdProvider_LogoutDeveloperId_GHES_Success()
+    {
+        // Setup CredentialVault with a dummy testuser and valid PAT for Github Enterprise Server
+        var credentialVault = SetupCredentialVaultWithGHESTestUser();
+
+        // Test whether the DeveloperIdProvider can restore the saved credentials
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+        var resultGetLoggedInDeveloperIds = devIdProvider.GetLoggedInDeveloperIds();
+
+        Assert.IsNotNull(resultGetLoggedInDeveloperIds);
+        Assert.AreEqual(ProviderOperationStatus.Success, resultGetLoggedInDeveloperIds.Result.Status);
+        Assert.AreEqual(1, resultGetLoggedInDeveloperIds.DeveloperIds.Count());
+        var devId = resultGetLoggedInDeveloperIds.DeveloperIds.First();
+        Assert.IsNotNull(devId);
+
+        var resultLogoutDeveloperId = devIdProvider.LogoutDeveloperId(devId);
+        Assert.IsNotNull(resultLogoutDeveloperId);
+        Assert.AreEqual(ProviderOperationStatus.Success, resultLogoutDeveloperId.Status);
+        Assert.AreEqual(AuthenticationState.LoggedOut, devIdProvider.GetDeveloperIdState(devId));
+
+        credentialVault.RemoveAllCredentials();
+        Assert.AreEqual(0, credentialVault.GetAllCredentials().Count());
+    }
+}

--- a/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
+++ b/test/GitHubExtension/DeveloperId/DeveloperIdProviderTests.cs
@@ -130,7 +130,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     public void DeveloperIdProvider_GetDeveloperIds_InvalidPAT()
     {
         // Setup CredentialVault with a dummy testuser and invalid PAT for Github.com

--- a/test/GitHubExtension/DeveloperId/DeveloperIdTestsSetup.cs
+++ b/test/GitHubExtension/DeveloperId/DeveloperIdTestsSetup.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Security;
 using GitHubExtension.DeveloperId;
-using Microsoft.UI;
-using Microsoft.Windows.DevHome.SDK;
-using Octokit;
-using Windows.Foundation;
 
 namespace GitHubExtension.Test;
 
@@ -41,102 +36,6 @@ public partial class DeveloperIdTests
         }
     }
 
-    public class MockExtensionAdaptiveCard : IExtensionAdaptiveCard
-    {
-        private int updateCount;
-
-        public int UpdateCount
-        {
-            get => updateCount;
-            set => updateCount = value;
-        }
-
-        public MockExtensionAdaptiveCard(string templateJson, string dataJson, string state)
-        {
-            TemplateJson = templateJson;
-            DataJson = dataJson;
-            State = state;
-        }
-
-        public string DataJson
-        {
-            get; set;
-        }
-
-        public string State
-        {
-            get; set;
-        }
-
-        public string TemplateJson
-        {
-            get; set;
-        }
-
-        public ProviderOperationResult Update(string templateJson, string dataJson, string state)
-        {
-            UpdateCount++;
-            TemplateJson = templateJson;
-            DataJson = dataJson;
-            State = state;
-            return new ProviderOperationResult(ProviderOperationStatus.Success, null, "Update() succeeded", "Update() succeeded");
-        }
-    }
-
-    public class MockDeveloperIdProvider : IDeveloperIdProviderInternal
-    {
-        private static MockDeveloperIdProvider? instance;
-
-        public string DisplayName => throw new NotImplementedException();
-
-        public event TypedEventHandler<IDeveloperIdProvider, IDeveloperId> Changed;
-
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-
-        public AuthenticationExperienceKind GetAuthenticationExperienceKind() => throw new NotImplementedException();
-
-        public AuthenticationState GetDeveloperIdState(IDeveloperId developerId) => throw new NotImplementedException();
-
-        public DeveloperIdsResult GetLoggedInDeveloperIds() => throw new NotImplementedException();
-
-        public AdaptiveCardSessionResult GetLoginAdaptiveCardSession() => throw new NotImplementedException();
-
-        public Windows.Foundation.IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync()
-        {
-            return Task.Run(() =>
-            {
-                return (IDeveloperId)new DeveloperId.DeveloperId(string.Empty, string.Empty, string.Empty, string.Empty, new GitHubClient(new ProductHeaderValue("Test")));
-            }).AsAsyncOperation();
-        }
-
-        public DeveloperId.DeveloperId LoginNewDeveloperIdWithPAT(Uri hostAddress, SecureString personalAccessToken)
-        {
-            // This is a mock method, so we don't need to do anything here. Using Changed to avoid build warning.
-            _ = Changed.GetInvocationList();
-            return new DeveloperId.DeveloperId(string.Empty, string.Empty, string.Empty, string.Empty, new GitHubClient(new ProductHeaderValue("Test")));
-        }
-
-        public ProviderOperationResult LogoutDeveloperId(IDeveloperId developerId) => throw new NotImplementedException();
-
-        public IAsyncOperation<DeveloperIdResult> ShowLogonSession(WindowId windowHandle) => throw new NotImplementedException();
-
-        private MockDeveloperIdProvider()
-        {
-            Changed += (IDeveloperIdProvider sender, IDeveloperId args) => { };
-        }
-
-        public static MockDeveloperIdProvider GetInstance()
-        {
-            instance ??= new MockDeveloperIdProvider();
-            return instance;
-        }
-
-        public IEnumerable<DeveloperId.DeveloperId> GetLoggedInDeveloperIdsInternal() => throw new NotImplementedException();
-    }
-
     public TestContext? TestContext
     {
         get;
@@ -158,9 +57,10 @@ public partial class DeveloperIdTests
         var testListener = new TestListener("TestListener", TestContext!);
         log.AddListener(testListener);
         DataModel.Log.Attach(log);
+        DeveloperId.Log.Attach(log);
         TestOptions = TestHelpers.SetupTempTestOptions(TestContext!);
 
-        TestContext?.WriteLine("DeveloperIdTests use the same credential store as Dev Home Github Extension");
+        TestContext?.WriteLine("DeveloperIdTests may use the same credential store as Dev Home Github Extension");
 
         // Remove any existing credentials
         var credentialVault = new CredentialVault();

--- a/test/GitHubExtension/DeveloperId/DeveloperIdTestsSetup.cs
+++ b/test/GitHubExtension/DeveloperId/DeveloperIdTestsSetup.cs
@@ -1,11 +1,142 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Security;
+using GitHubExtension.DeveloperId;
+using Microsoft.UI;
+using Microsoft.Windows.DevHome.SDK;
+using Octokit;
+using Windows.Foundation;
+
 namespace GitHubExtension.Test;
 
 [TestClass]
 public partial class DeveloperIdTests
 {
+    public class RuntimeDataRow
+    {
+        public string? InitialState
+        {
+            get; set;
+        }
+
+        public string? Actions
+        {
+            get; set;
+        }
+
+        public string? Inputs
+        {
+            get; set;
+        }
+
+        public string? FinalState
+        {
+            get; set;
+        }
+
+        public string? HostAddress
+        {
+            get; set;
+        }
+    }
+
+    public class MockExtensionAdaptiveCard : IExtensionAdaptiveCard
+    {
+        private int updateCount;
+
+        public int UpdateCount
+        {
+            get => updateCount;
+            set => updateCount = value;
+        }
+
+        public MockExtensionAdaptiveCard(string templateJson, string dataJson, string state)
+        {
+            TemplateJson = templateJson;
+            DataJson = dataJson;
+            State = state;
+        }
+
+        public string DataJson
+        {
+            get; set;
+        }
+
+        public string State
+        {
+            get; set;
+        }
+
+        public string TemplateJson
+        {
+            get; set;
+        }
+
+        public ProviderOperationResult Update(string templateJson, string dataJson, string state)
+        {
+            UpdateCount++;
+            TemplateJson = templateJson;
+            DataJson = dataJson;
+            State = state;
+            return new ProviderOperationResult(ProviderOperationStatus.Success, null, "Update() succeeded", "Update() succeeded");
+        }
+    }
+
+    public class MockDeveloperIdProvider : IDeveloperIdProviderInternal
+    {
+        private static MockDeveloperIdProvider? instance;
+
+        public string DisplayName => throw new NotImplementedException();
+
+        public event TypedEventHandler<IDeveloperIdProvider, IDeveloperId> Changed;
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        public AuthenticationExperienceKind GetAuthenticationExperienceKind() => throw new NotImplementedException();
+
+        public AuthenticationState GetDeveloperIdState(IDeveloperId developerId) => throw new NotImplementedException();
+
+        public DeveloperIdsResult GetLoggedInDeveloperIds() => throw new NotImplementedException();
+
+        public AdaptiveCardSessionResult GetLoginAdaptiveCardSession() => throw new NotImplementedException();
+
+        public Windows.Foundation.IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync()
+        {
+            return Task.Run(() =>
+            {
+                return (IDeveloperId)new DeveloperId.DeveloperId(string.Empty, string.Empty, string.Empty, string.Empty, new GitHubClient(new ProductHeaderValue("Test")));
+            }).AsAsyncOperation();
+        }
+
+        public DeveloperId.DeveloperId LoginNewDeveloperIdWithPAT(Uri hostAddress, SecureString personalAccessToken)
+        {
+            // This is a mock method, so we don't need to do anything here. Using Changed to avoid build warning.
+            _ = Changed.GetInvocationList();
+            return new DeveloperId.DeveloperId(string.Empty, string.Empty, string.Empty, string.Empty, new GitHubClient(new ProductHeaderValue("Test")));
+        }
+
+        public ProviderOperationResult LogoutDeveloperId(IDeveloperId developerId) => throw new NotImplementedException();
+
+        public IAsyncOperation<DeveloperIdResult> ShowLogonSession(WindowId windowHandle) => throw new NotImplementedException();
+
+        private MockDeveloperIdProvider()
+        {
+            Changed += (IDeveloperIdProvider sender, IDeveloperId args) => { };
+        }
+
+        public static MockDeveloperIdProvider GetInstance()
+        {
+            instance ??= new MockDeveloperIdProvider();
+            return instance;
+        }
+
+        public IEnumerable<DeveloperId.DeveloperId> GetLoggedInDeveloperIdsInternal() => throw new NotImplementedException();
+    }
+
     public TestContext? TestContext
     {
         get;
@@ -30,6 +161,10 @@ public partial class DeveloperIdTests
         TestOptions = TestHelpers.SetupTempTestOptions(TestContext!);
 
         TestContext?.WriteLine("DeveloperIdTests use the same credential store as Dev Home Github Extension");
+
+        // Remove any existing credentials
+        var credentialVault = new CredentialVault();
+        credentialVault.RemoveAllCredentials();
     }
 
     [TestCleanup]

--- a/test/GitHubExtension/DeveloperId/DeveloperIdTestsSetup.cs
+++ b/test/GitHubExtension/DeveloperId/DeveloperIdTestsSetup.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+namespace GitHubExtension.Test;
+
+[TestClass]
+public partial class DeveloperIdTests
+{
+    public TestContext? TestContext
+    {
+        get;
+        set;
+    }
+
+    private TestOptions testOptions = new ();
+
+    private TestOptions TestOptions
+    {
+        get => testOptions;
+        set => testOptions = value;
+    }
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        using var log = new DevHome.Logging.Logger("TestStore", TestOptions.LogOptions);
+        var testListener = new TestListener("TestListener", TestContext!);
+        log.AddListener(testListener);
+        DataModel.Log.Attach(log);
+        TestOptions = TestHelpers.SetupTempTestOptions(TestContext!);
+
+        TestContext?.WriteLine("DeveloperIdTests use the same credential store as Dev Home Github Extension");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        TestHelpers.CleanupTempTestOptions(TestOptions, TestContext!);
+    }
+}

--- a/test/GitHubExtension/DeveloperId/FunctionalTests.cs
+++ b/test/GitHubExtension/DeveloperId/FunctionalTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using GitHubExtension.DeveloperId;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace GitHubExtension.Test;
+public partial class DeveloperIdTests
+{
+    [TestMethod]
+    [TestCategory("Functional")]
+    public async Task FunctionalTest_RestoreAndRetrieveRepositoriesAsync()
+    {
+        var credentialVault = SetupCredentialVaultWithTestUser();
+
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+
+        var devIds = devIdProvider.GetLoggedInDeveloperIds().DeveloperIds;
+        Assert.IsNotNull(devIds);
+        Assert.AreEqual(1, devIds.Count());
+
+        var devId = devIds.First();
+        Assert.IsNotNull(devId);
+
+        // Get Repository Provider
+        var manualResetEvent = new ManualResetEvent(false);
+        var githubExtension = new GitHubExtension(manualResetEvent);
+        var repositoryObject = githubExtension.GetProvider(ProviderType.Repository);
+        Assert.IsNotNull(repositoryObject);
+
+        var repositoryProvider = repositoryObject as IRepositoryProvider;
+        Assert.IsNotNull(repositoryProvider);
+
+        var result = await repositoryProvider.GetRepositoriesAsync(devId);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+        Assert.IsNotNull(result.Repositories);
+        Assert.IsTrue(result.Repositories.Count() > 1);
+
+        credentialVault.RemoveAllCredentials();
+    }
+
+    [TestMethod]
+    [TestCategory("Functional")]
+    public async Task FunctionalTest_GHES_RestoreAndRetrieveRepositoriesAsync()
+    {
+        var credentialVault = SetupCredentialVaultWithGHESTestUser();
+
+        var devIdProvider = DeveloperIdProvider.GetInstance();
+        Assert.IsNotNull(devIdProvider);
+
+        var devIds = devIdProvider.GetLoggedInDeveloperIds().DeveloperIds;
+        Assert.IsNotNull(devIds);
+        Assert.AreEqual(1, devIds.Count());
+
+        var devId = devIds.First();
+        Assert.IsNotNull(devId);
+
+        // Get Repository Provider
+        var manualResetEvent = new ManualResetEvent(false);
+        var githubExtension = new GitHubExtension(manualResetEvent);
+        var repositoryObject = githubExtension.GetProvider(ProviderType.Repository);
+        Assert.IsNotNull(repositoryObject);
+
+        var repositoryProvider = repositoryObject as IRepositoryProvider;
+        Assert.IsNotNull(repositoryProvider);
+
+        var result = await repositoryProvider.GetRepositoriesAsync(devId);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(ProviderOperationStatus.Success, result.Result.Status);
+        Assert.IsNotNull(result.Repositories);
+        Assert.IsTrue(result.Repositories.Count() > 1);
+
+        credentialVault.RemoveAllCredentials();
+    }
+}

--- a/test/GitHubExtension/DeveloperId/FunctionalTests.cs
+++ b/test/GitHubExtension/DeveloperId/FunctionalTests.cs
@@ -8,7 +8,7 @@ namespace GitHubExtension.Test;
 public partial class DeveloperIdTests
 {
     [TestMethod]
-    [TestCategory("Functional")]
+    [TestCategory("LiveData")]
     public async Task FunctionalTest_RestoreAndRetrieveRepositoriesAsync()
     {
         var credentialVault = SetupCredentialVaultWithTestUser();
@@ -42,7 +42,7 @@ public partial class DeveloperIdTests
     }
 
     [TestMethod]
-    [TestCategory("Functional")]
+    [TestCategory("LiveData")]
     public async Task FunctionalTest_GHES_RestoreAndRetrieveRepositoriesAsync()
     {
         var credentialVault = SetupCredentialVaultWithGHESTestUser();

--- a/test/GitHubExtension/DeveloperId/LoginUITests.cs
+++ b/test/GitHubExtension/DeveloperId/LoginUITests.cs
@@ -62,7 +62,6 @@ public partial class DeveloperIdTests
     [TestCategory("Unit")]
     [DataRow("LoginPage", LoginUITestData.GithubButtonAction, LoginUITestData.GithubButtonInput, "LoginSucceededPage", 3)]
     [DataRow("LoginPage", LoginUITestData.GithubEnterpriseButtonAction, LoginUITestData.GithubEnterpriseButtonInput, "EnterpriseServerPage")]
-    [DataRow("LoginPage", LoginUITestData.GithubEnterpriseButtonAction, LoginUITestData.GithubEnterpriseButtonInput, "EnterpriseServerPage")]
     [DataRow("EnterpriseServerPage", LoginUITestData.NextButtonAction, LoginUITestData.BadUrlEnterpriseServerInput, "EnterpriseServerPage")]
     [DataRow("EnterpriseServerPage", LoginUITestData.NextButtonAction, LoginUITestData.UnreachableUrlEnterpriseServerInput, "EnterpriseServerPage")]
     [DataRow("EnterpriseServerPage", LoginUITestData.CancelButtonAction, LoginUITestData.CancelButtonInput, "LoginPage")]
@@ -148,7 +147,7 @@ public partial class DeveloperIdTests
      * DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER_PAT : A valid Personal Access Token for the GitHub Enterprise Server set in DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER (with at least repo_public permissions)
      */
     [TestMethod]
-    [TestCategory("Unit")]
+    [TestCategory("LiveData")]
     public async Task LoginUI_ControllerPATLoginTest_Success()
     {
         // Create DataRows during Runtime since these need Env vars

--- a/test/GitHubExtension/DeveloperId/LoginUITests.cs
+++ b/test/GitHubExtension/DeveloperId/LoginUITests.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using GitHubExtension.DeveloperId;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace GitHubExtension.Test;
+
+// Unit Tests for LoginUIController and LoginUI
+public partial class DeveloperIdTests
+{
+    public const string EMPTYJSON = "{}";
+
+    private struct LoginUITestData
+    {
+        public const string GithubButtonAction = "{\"id\":\"Personal\",\"style\":\"positive\",\"title\":\"Sign in to github.com\",\"tooltip\":\"Opens the browser to log you into GitHub\",\"type\":\"Action.Submit\"}";
+        public const string GithubButtonInput = EMPTYJSON;
+
+        public const string GithubEnterpriseButtonAction = "{\"id\":\"Enterprise\",\"title\":\"Sign in to GitHub Enterprise Server\",\"tooltip\":\"Lets you enter the host address of your GitHub Enterprise Server\",\"type\":\"Action.Submit\"}";
+        public const string GithubEnterpriseButtonInput = EMPTYJSON;
+
+        public const string CancelButtonAction = "{\"id\":\"Cancel\",\"title\":\"Cancel\",\"type\":\"Action.Submit\"}";
+        public const string CancelButtonInput = EMPTYJSON;
+
+        public const string NextButtonAction = "{\"id\":\"Next\",\"style\":\"positive\",\"title\":\"Next\",\"type\":\"Action.Submit\"}";
+        public const string BadUrlEnterpriseServerInput = "{\"EnterpriseServer\":\"badUrlEnterpriseServer\"}";
+        public const string UnreachableUrlEnterpriseServerInput = "{\"EnterpriseServer\":\"https://www.bing.com\"}";
+        public static readonly string GoodUrlEnterpriseServerInput = "{\"EnterpriseServer\":\"" + Environment.GetEnvironmentVariable("DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER") + "\"}";
+        public const string GithubUrlEnterpriseServerInput = "{\"EnterpriseServer\":\"https://www.github.com\"}";
+
+        public const string ClickHereUrlAction = "{\"role\":\"Link\",\"type\":\"Action.OpenUrl\",\"url\":\"https://www.bing.com\"}";
+        public const string ClickHereUrlInput = EMPTYJSON;
+
+        public const string ConnectButtonAction = "{\"id\":\"Connect\",\"style\":\"positive\",\"title\":\"Connect\",\"type\":\"Action.Submit\"}";
+        public const string NullPATInput = "{\"PAT\":\"\"}";
+        public const string BadPATInput = "{\"PAT\":\"Enterprise\"}";
+        public static readonly string GoodPATEnterpriseServerInput = "{\"PAT\":\"" + Environment.GetEnvironmentVariable("DEV_HOME_TEST_GITHUB_ENTERPRISE_SERVER_PAT") + "\"}";
+        public static readonly string GoodPATGithubComInput = "{\"PAT\":\"" + Environment.GetEnvironmentVariable("DEV_HOME_TEST_GITHUB_COM_PAT") + "\"}";
+    }
+
+    public class TestExtensionAdaptiveCard : IExtensionAdaptiveCard
+    {
+        private int updateCount;
+
+        public int UpdateCount
+        {
+            get => updateCount;
+            set => updateCount = value;
+        }
+
+        public TestExtensionAdaptiveCard(string templateJson, string dataJson, string state)
+        {
+            TemplateJson = templateJson;
+            DataJson = dataJson;
+            State = state;
+        }
+
+        public string DataJson
+        {
+            get; set;
+        }
+
+        public string State
+        {
+            get; set;
+        }
+
+        public string TemplateJson
+        {
+            get; set;
+        }
+
+        public ProviderOperationResult Update(string templateJson, string dataJson, string state)
+        {
+            UpdateCount++;
+            TemplateJson = templateJson;
+            DataJson = dataJson;
+            State = state;
+            return new ProviderOperationResult(ProviderOperationStatus.Success, null, "Update() succeeded", "Update() succeeded");
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void LoginUIControllerInitializeTest()
+    {
+        var testExtensionAdaptiveCard = new TestExtensionAdaptiveCard(string.Empty, string.Empty, string.Empty);
+        Assert.AreEqual(0, testExtensionAdaptiveCard.UpdateCount);
+
+        // Create a LoginUIController and initialize it with the testExtensionAdaptiveCard.
+        var controller = new LoginUIController();
+        controller.Initialize(testExtensionAdaptiveCard);
+
+        // Verify that the initial state is the login page.
+        Assert.IsTrue(testExtensionAdaptiveCard.State == Enum.GetName(typeof(LoginUIState), LoginUIState.LoginPage));
+        Assert.AreEqual(1, testExtensionAdaptiveCard.UpdateCount);
+
+        controller.Dispose();
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    [DataRow("LoginPage", LoginUITestData.GithubEnterpriseButtonAction, LoginUITestData.GithubEnterpriseButtonInput, "EnterpriseServerPage")]
+    [DataRow("LoginPage", LoginUITestData.GithubEnterpriseButtonAction, LoginUITestData.GithubEnterpriseButtonInput, "EnterpriseServerPage")]
+    [DataRow("EnterpriseServerPage", LoginUITestData.NextButtonAction, LoginUITestData.BadUrlEnterpriseServerInput, "EnterpriseServerPage")]
+    [DataRow("EnterpriseServerPage", LoginUITestData.NextButtonAction, LoginUITestData.UnreachableUrlEnterpriseServerInput, "EnterpriseServerPage")]
+    [DataRow("EnterpriseServerPage", LoginUITestData.CancelButtonAction, LoginUITestData.CancelButtonInput, "LoginPage")]
+    [DataRow("EnterpriseServerPATPage", LoginUITestData.CancelButtonAction, LoginUITestData.CancelButtonInput, "EnterpriseServerPage")]
+    [DataRow("EnterpriseServerPATPage", LoginUITestData.ClickHereUrlAction, LoginUITestData.ClickHereUrlInput, "EnterpriseServerPATPage", 1)]
+    [DataRow("EnterpriseServerPATPage", LoginUITestData.ConnectButtonAction, LoginUITestData.NullPATInput, "EnterpriseServerPATPage")]
+    [DataRow("EnterpriseServerPATPage", LoginUITestData.ConnectButtonAction, LoginUITestData.BadPATInput, "EnterpriseServerPATPage")]
+
+    // Cannot test with LoginPAge since that launches browser
+    // [DataRow("LoginPage", LoginUITestData.GithubButtonAction, LoginUITestData.GithubButtonInput, "WaitingPage", 2)]
+    public async Task LoginUIControllerTest(
+        string initialState, string actions, string inputs, string finalState, int numOfFinalUpdates = 2)
+    {
+        var testExtensionAdaptiveCard = new TestExtensionAdaptiveCard(string.Empty, string.Empty, string.Empty);
+        Assert.AreEqual(0, testExtensionAdaptiveCard.UpdateCount);
+
+        // Create a LoginUIController and initialize it with the testExtensionAdaptiveCard.
+        var controller = new LoginUIController();
+        controller.Initialize(testExtensionAdaptiveCard);
+        Assert.AreEqual(1, testExtensionAdaptiveCard.UpdateCount);
+
+        // Set the initial state.
+        testExtensionAdaptiveCard.State = initialState;
+        Assert.AreEqual(initialState, testExtensionAdaptiveCard.State);
+
+        // Set HostAddress for EnterpriseServerPATPage to make this a valid state
+        if (initialState == "EnterpriseServerPATPage")
+        {
+            controller.HostAddress = new Uri("https://www.github.com");
+            Assert.AreEqual("https://www.github.com", controller.HostAddress.OriginalString);
+        }
+
+        // Call OnAction() with the actions and inputs.
+        await controller.OnAction(actions, inputs);
+
+        // Verify the final state
+        Assert.AreEqual(finalState, testExtensionAdaptiveCard.State);
+        Assert.AreEqual(numOfFinalUpdates, testExtensionAdaptiveCard.UpdateCount);
+
+        controller.Dispose();
+    }
+}

--- a/test/GitHubExtension/Mocks/DeveloperIdProvider.cs
+++ b/test/GitHubExtension/Mocks/DeveloperIdProvider.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Security;
+using GitHubExtension.DeveloperId;
+using Microsoft.UI;
+using Microsoft.Windows.DevHome.SDK;
+using Octokit;
+using Windows.Foundation;
+
+namespace GitHubExtension.Test.Mocks;
+
+public class MockDeveloperIdProvider : IDeveloperIdProviderInternal
+{
+    private static MockDeveloperIdProvider? instance;
+
+    public string DisplayName => throw new NotImplementedException();
+
+    public event TypedEventHandler<IDeveloperIdProvider, IDeveloperId> Changed;
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    public AuthenticationExperienceKind GetAuthenticationExperienceKind() => throw new NotImplementedException();
+
+    public AuthenticationState GetDeveloperIdState(IDeveloperId developerId) => throw new NotImplementedException();
+
+    public DeveloperIdsResult GetLoggedInDeveloperIds() => throw new NotImplementedException();
+
+    public AdaptiveCardSessionResult GetLoginAdaptiveCardSession() => throw new NotImplementedException();
+
+    public IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync()
+    {
+        return Task.Run(() =>
+        {
+            return (IDeveloperId)new DeveloperId.DeveloperId(string.Empty, string.Empty, string.Empty, string.Empty, new GitHubClient(new ProductHeaderValue("Test")));
+        }).AsAsyncOperation();
+    }
+
+    public DeveloperId.DeveloperId LoginNewDeveloperIdWithPAT(Uri hostAddress, SecureString personalAccessToken)
+    {
+        var pat = new System.Net.NetworkCredential(string.Empty, personalAccessToken).Password;
+        if (pat == DeveloperIdTests.LoginUITestData.BadPAT)
+        {
+            throw new InvalidOperationException("Invalid PAT");
+        }
+
+        // This is a mock method, so we don't need to do anything here. Using Changed to avoid build warning.
+        _ = Changed.GetInvocationList();
+        return new DeveloperId.DeveloperId(string.Empty, string.Empty, string.Empty, string.Empty, new GitHubClient(new ProductHeaderValue("Test")));
+    }
+
+    public ProviderOperationResult LogoutDeveloperId(IDeveloperId developerId) => throw new NotImplementedException();
+
+    public IAsyncOperation<DeveloperIdResult> ShowLogonSession(WindowId windowHandle) => throw new NotImplementedException();
+
+    private MockDeveloperIdProvider()
+    {
+        Changed += (sender, args) => { };
+    }
+
+    public static MockDeveloperIdProvider GetInstance()
+    {
+        instance ??= new MockDeveloperIdProvider();
+        return instance;
+    }
+
+    public IEnumerable<DeveloperId.DeveloperId> GetLoggedInDeveloperIdsInternal() => throw new NotImplementedException();
+}
+
+public class MockExtensionAdaptiveCard : IExtensionAdaptiveCard
+{
+    private int updateCount;
+
+    public int UpdateCount
+    {
+        get => updateCount;
+        set => updateCount = value;
+    }
+
+    public MockExtensionAdaptiveCard(string templateJson, string dataJson, string state)
+    {
+        TemplateJson = templateJson;
+        DataJson = dataJson;
+        State = state;
+    }
+
+    public string DataJson
+    {
+        get; set;
+    }
+
+    public string State
+    {
+        get; set;
+    }
+
+    public string TemplateJson
+    {
+        get; set;
+    }
+
+    public ProviderOperationResult Update(string templateJson, string dataJson, string state)
+    {
+        UpdateCount++;
+        TemplateJson = templateJson;
+        DataJson = dataJson;
+        State = state;
+        return new ProviderOperationResult(ProviderOperationStatus.Success, null, "Update() succeeded", "Update() succeeded");
+    }
+}

--- a/test/GitHubExtension/Mocks/DeveloperIdProvider.cs
+++ b/test/GitHubExtension/Mocks/DeveloperIdProvider.cs
@@ -27,7 +27,7 @@ public class MockDeveloperIdProvider : IDeveloperIdProviderInternal
 
     public AuthenticationState GetDeveloperIdState(IDeveloperId developerId) => throw new NotImplementedException();
 
-    public DeveloperIdsResult GetLoggedInDeveloperIds() => throw new NotImplementedException();
+    public DeveloperIdsResult GetLoggedInDeveloperIds() => new (new List<DeveloperId.DeveloperId>());
 
     public AdaptiveCardSessionResult GetLoginAdaptiveCardSession() => throw new NotImplementedException();
 
@@ -67,7 +67,7 @@ public class MockDeveloperIdProvider : IDeveloperIdProviderInternal
         return instance;
     }
 
-    public IEnumerable<DeveloperId.DeveloperId> GetLoggedInDeveloperIdsInternal() => throw new NotImplementedException();
+    public IEnumerable<DeveloperId.DeveloperId> GetLoggedInDeveloperIdsInternal() => new List<DeveloperId.DeveloperId>();
 }
 
 public class MockExtensionAdaptiveCard : IExtensionAdaptiveCard

--- a/test/UITest/GitHubExtensionSession.cs
+++ b/test/UITest/GitHubExtensionSession.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;


### PR DESCRIPTION
## Summary of the pull request
This PR contains the following changes:
- Adds GitHub Enterprise Server (GHES) v3 Support (supported version determined by Octokit)
- Adds LoginUI page for GHES flow to enter PAT
- Refactors LoginUIController flow to be more encapsulated into Pages
- Refactors CredentialVault to allow test configuration
- Adds Unit Tests for DeveloperID components
- Adds Functional tests for restoring and using saved credentials for repository query
- Catches (and logs) a crash during Startup due to bad saved credentials

- Also, enables multi-user support for widgets (requires Widget UI update in a follow-up PR)

## References and relevant issues
https://github.com/microsoft/devhome/issues/825
https://github.com/microsoft/devhomegithubextension/issues/235

## LoginUI flow for GHES
![Untitled video - Made with Clipchamp](https://github.com/microsoft/devhomegithubextension/assets/16733941/843f5556-3e97-4687-b8a9-1cda46afca1d)
Not uploading gif of 2nd page since it has personal info. Please try it out yourself.

## Validation steps performed
Ran old and new tests, and manually ran through login flow, widget and setup flow. 

## PR checklist
- [x] Closes #xxx
- [X ] Tests added - Currently fails due to lack of Env variables. Looking into this.
- [ ] Documentation updated
