### PR TITLE
Update pin widget flow

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubAssignedWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubAssignedWidget.cs
@@ -139,7 +139,7 @@ internal class GitHubAssignedWidget : GitHubWidget
         }
     }
 
-    public new void UpdateActivityState()
+    public override void UpdateActivityState()
     {
         // State logic for the Widget:
         // Signed in -> Configure -> Active / Inactive per widget host.
@@ -235,7 +235,7 @@ internal class GitHubAssignedWidget : GitHubWidget
 
     public void LoadContentData(IEnumerable<Octokit.Issue> items)
     {
-        Log.Logger()?.ReportDebug(Name, ShortId, "Getting Data for Assigned in Widget");
+        Log.Logger()?.ReportDebug(Name, ShortId, "Getting Data for Assigned to Widget");
 
         try
         {
@@ -328,7 +328,6 @@ internal class GitHubAssignedWidget : GitHubWidget
         {
             { "showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory) },
             { "savedShowCategory", savedShowCategory != null ? "savedShowCategory" : string.Empty },
-            { "configuring", true },
         };
         return configurationData.ToJsonString();
     }

--- a/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
@@ -199,7 +199,7 @@ internal class GitHubIssuesWidget : GitHubWidget
             WidgetPageState.SignIn => GetSignIn(),
             WidgetPageState.Configure => GetConfiguration(RepositoryUrl),
             WidgetPageState.Content => ContentData,
-            WidgetPageState.Loading => new JsonObject { { "configuring", true } }.ToJsonString(),
+            WidgetPageState.Loading => EmptyJson,
             _ => throw new NotImplementedException(Page.GetType().Name),
         };
     }

--- a/src/GitHubExtension/Widgets/GitHubMentionedInWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubMentionedInWidget.cs
@@ -105,7 +105,7 @@ internal class GitHubMentionedInWidget : GitHubWidget
         UpdateActivityState();
     }
 
-    public new void UpdateActivityState()
+    public override void UpdateActivityState()
     {
         // State logic for the Widget:
         // Signed in -> Configure -> Active / Inactive per widget host.
@@ -304,7 +304,6 @@ internal class GitHubMentionedInWidget : GitHubWidget
         {
             { "showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory) },
             { "savedShowCategory", savedShowCategory != null ? "savedShowCategory" : string.Empty },
-            { "configuring", true },
         };
         return configurationData.ToJsonString();
     }

--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -172,7 +172,7 @@ internal class GitHubPullsWidget : GitHubWidget
             WidgetPageState.SignIn => GetSignIn(),
             WidgetPageState.Configure => GetConfiguration(RepositoryUrl),
             WidgetPageState.Content => ContentData,
-            WidgetPageState.Loading => new JsonObject { { "configuring", true } }.ToJsonString(),
+            WidgetPageState.Loading => EmptyJson,
             _ => throw new NotImplementedException(Page.GetType().Name),
         };
     }

--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
 using GitHubExtension.Widgets.Enums;
@@ -73,7 +71,7 @@ internal class GitHubReviewWidget : GitHubWidget
         UpdateActivityState();
     }
 
-    public new void UpdateActivityState()
+    public override void UpdateActivityState()
     {
         // State logic for the Widget: (no configuration is needed)
         // Signed in -> Active / Inactive per widget host.
@@ -156,7 +154,7 @@ internal class GitHubReviewWidget : GitHubWidget
 
     public void LoadContentData(IEnumerable<Octokit.Issue> items)
     {
-        Log.Logger()?.ReportDebug(Name, ShortId, "Getting Data for Mentioned in Widget");
+        Log.Logger()?.ReportDebug(Name, ShortId, "Getting Data for Review requested Widget");
 
         try
         {
@@ -232,7 +230,7 @@ internal class GitHubReviewWidget : GitHubWidget
         return page switch
         {
             WidgetPageState.SignIn => new JsonObject { { "message", Resources.GetResource(@"Widget_Template/SignInRequired", Log.Logger()) } }.ToJsonString(),
-            WidgetPageState.Configure => EmptyJson,
+            WidgetPageState.Configure => throw new NotImplementedException(Page.GetType().Name),
             WidgetPageState.Content => ContentData,
             WidgetPageState.Loading => EmptyJson,
             _ => throw new NotImplementedException(Page.GetType().Name),

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -228,7 +228,6 @@ public abstract class GitHubWidget : WidgetImpl
         if (data == string.Empty)
         {
             configurationData.Add("hasConfiguration", false);
-            configurationData.Add("configuring", true);
             var repositoryData = new JsonObject
             {
                 { "url", string.Empty },
@@ -279,7 +278,6 @@ public abstract class GitHubWidget : WidgetImpl
             {
                 Log.Logger()?.ReportError(Name, ShortId, $"Failed getting configuration information for input url: {data}", ex);
                 configurationData.Add("hasConfiguration", false);
-                configurationData.Add("configuring", true);
 
                 var repositoryData = new JsonObject
                 {
@@ -302,7 +300,6 @@ public abstract class GitHubWidget : WidgetImpl
         var signInData = new JsonObject
         {
             { "message", Resources.GetResource(@"Widget_Template/SignInRequired", Log.Logger()) },
-            { "configuring", true },
         };
 
         return signInData.ToString();
@@ -314,7 +311,7 @@ public abstract class GitHubWidget : WidgetImpl
         return authProvider.GetLoggedInDeveloperIds().DeveloperIds.Any();
     }
 
-    public void UpdateActivityState()
+    public override void UpdateActivityState()
     {
         // State logic for the Widget:
         // Signed in -> Valid Repository Url -> Active / Inactive per widget host.

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
@@ -68,19 +68,6 @@
         },
         {
           "type": "TextBlock",
-          "text": "%Widget_Template/Label%",
-          "wrap": true,
-          "size": "Small"
-        },
-        {
-          "type": "TextBlock",
-          "text": "${label}",
-          "wrap": true,
-          "weight": "bolder",
-          "spacing": "None"
-        },
-        {
-          "type": "TextBlock",
           "text": "%Widget_Template/Author%",
           "wrap": true,
           "size": "Small"
@@ -88,19 +75,6 @@
         {
           "type": "TextBlock",
           "text": "${owner}",
-          "wrap": true,
-          "weight": "bolder",
-          "spacing": "None"
-        },
-        {
-          "type": "TextBlock",
-          "text": "%Widget_Template/Project%",
-          "wrap": true,
-          "size": "Small"
-        },
-        {
-          "type": "TextBlock",
-          "text": "${Project}",
           "wrap": true,
           "weight": "bolder",
           "spacing": "None"

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
@@ -115,7 +115,6 @@
     {
       "type": "ColumnSet",
       "spacing": "Medium",
-      "$when": "${$root.savedRepositoryUrl != \"\"}",
       "columns": [
         {
           "type": "Column",
@@ -142,7 +141,8 @@
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/Cancel%",
                       "verb": "Cancel",
-                      "tooltip": "%Widget_Template_Tooltip/Cancel%"
+                      "tooltip": "%Widget_Template_Tooltip/Cancel%",
+                      "isEnabled": "${$root.savedRepositoryUrl != \"\"}"
                     }
                   ]
                 }

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -100,7 +100,6 @@
     {
       "type": "ColumnSet",
       "spacing": "Medium",
-      "$when": "${$root.savedRepositoryUrl != \"\"}",
       "columns": [
         {
           "type": "Column",
@@ -127,7 +126,8 @@
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/Cancel%",
                       "verb": "Cancel",
-                      "tooltip": "%Widget_Template_Tooltip/Cancel%"
+                      "tooltip": "%Widget_Template_Tooltip/Cancel%",
+                      "isEnabled": "${$root.savedRepositoryUrl != \"\"}"
                     }
                   ]
                 }

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -53,19 +53,6 @@
         },
         {
           "type": "TextBlock",
-          "text": "%Widget_Template/Label%",
-          "wrap": true,
-          "size": "Small"
-        },
-        {
-          "type": "TextBlock",
-          "text": "${label}",
-          "wrap": true,
-          "weight": "bolder",
-          "spacing": "None"
-        },
-        {
-          "type": "TextBlock",
           "text": "%Widget_Template/Author%",
           "wrap": true,
           "size": "Small"
@@ -73,19 +60,6 @@
         {
           "type": "TextBlock",
           "text": "${owner}",
-          "wrap": true,
-          "weight": "bolder",
-          "spacing": "None"
-        },
-        {
-          "type": "TextBlock",
-          "text": "%Widget_Template/Project%",
-          "wrap": true,
-          "size": "Small"
-        },
-        {
-          "type": "TextBlock",
-          "text": "${Project}",
           "wrap": true,
           "weight": "bolder",
           "spacing": "None"

--- a/src/GitHubExtension/Widgets/WidgetImpl.cs
+++ b/src/GitHubExtension/Widgets/WidgetImpl.cs
@@ -49,4 +49,6 @@ public abstract class WidgetImpl
     public abstract void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs);
 
     public abstract void OnWidgetContextChanged(WidgetContextChangedArgs contextChangedArgs);
+
+    public abstract void UpdateActivityState();
 }


### PR DESCRIPTION
## Summary of the pull request
Accommodate the updated pin widget flow from https://github.com/microsoft/devhome/pull/2110. Widgets are selected in the Add widget dialog and configured inline on the Dashboard, similar to how the Windows Widget Board does it.

## References and relevant issues

## Detailed description of the pull request / Additional comments
* Since we don't have to communicate to the host that we're in configuration mode anymore, it is removed from the Data json.
* Since there is no longer a different between "add" configuration state and "edit" configuration state, we can always show the Save and Cancel buttons in the Configuration template, although we only enable Cancel if there was once a valid state we can return to.
* Change `UpdateActivityState()` to use `override` keyword instead of `new`. By hiding the higher level method, the wrong one was being used. In the old flow, it happened to do the right thing, but wouldn't in the new flow.
* The Review Requested widget does not have a configure state, so throw an error if we request it.

PR in Draft until we get screenshot assets.

## Validation steps performed

## PR checklist
- [x] Closes #311
- [ ] Tests added/passed
- [ ] Documentation updated
