### PR TITLE
Fix Issue search sort order getting corrupted over time.

### DIFF
--- a/src/GitHubExtension/DataModel/DataObjects/SearchIssue.cs
+++ b/src/GitHubExtension/DataModel/DataObjects/SearchIssue.cs
@@ -70,7 +70,7 @@ public class SearchIssue
 
     public static void DeleteBefore(DataStore dataStore, Search search, DateTime date)
     {
-        // Delete delete out of date entires for a given search.
+        // Delete out of date entries for a given search.
         var sql = @"DELETE FROM SearchIssue WHERE TimeUpdated < $Time AND Search = $SearchId;";
         var command = dataStore.Connection!.CreateCommand();
         command.CommandText = sql;

--- a/src/GitHubExtension/DataModel/DataObjects/SearchIssue.cs
+++ b/src/GitHubExtension/DataModel/DataObjects/SearchIssue.cs
@@ -75,7 +75,7 @@ public class SearchIssue
         var command = dataStore.Connection!.CreateCommand();
         command.CommandText = sql;
         command.Parameters.AddWithValue("$Time", date.ToDataStoreInteger());
-        command.Parameters.AddWithValue("SearchId", search.Id);
+        command.Parameters.AddWithValue("$SearchId", search.Id);
         Log.Logger()?.ReportDebug(DataStore.GetCommandLogMessage(sql, command));
         var rowsDeleted = command.ExecuteNonQuery();
         Log.Logger()?.ReportDebug(DataStore.GetDeletedLogMessage(rowsDeleted));


### PR DESCRIPTION
## Summary of the pull request

This fixes an elusive search sort bug where over time the Issues widget when used with a Search query becomes corrupted and the search results go out of order.
 
## References and relevant issues
Closes #278 

## Detailed description of the pull request / Additional comments

This bug originates in the parameter of the pruning method.  The parameter for pruning the outdated search results was incorrectly specified (missing 1 character). This resulted in the actual query command once substituted to never match any records. Since nothing was ever removed when updating search results, the timestamp-based search result ordering was showing out of order.

Also fixed a horribly written comment.

## Validation steps performed

* I created the same search widget, then took a confirmed corrupted datastore that repro'd this issue and injected it into a built extension with the fix's datastore and restarted devhome to execute the updated code against the corrupted datastore. The result is that the issues search list was no longer corrupted and had only the current accurate results. This confirms that the fix heals an affected datastore without any action from the user other than taking an update with the fix.
* Also confirmed search issue widgets work as expected with the change.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
