### PR TITLE
[Dev][Deps] Update LibGit2Sharp to 0.29.0 to resolve cloning issues on Arm64

### DIFF
--- a/src/GitHubExtension/GitHubExtension.csproj
+++ b/src/GitHubExtension/GitHubExtension.csproj
@@ -72,7 +72,7 @@
   <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-      <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+      <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
       <PackageReference Include="MessageFormat" Version="6.0.2" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
       <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />

--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -207,7 +207,7 @@ public class RepositoryProvider : IRepositoryProvider
 
                 try
                 {
-                    cloneOptions.CredentialsProvider = (url, user, cred) => new LibGit2Sharp.UsernamePasswordCredentials
+                    cloneOptions.FetchOptions.CredentialsProvider = (url, user, cred) => new LibGit2Sharp.UsernamePasswordCredentials
                     {
                         // Password is a PAT unique to GitHub.
                         Username = loggedInDeveloperId.GetCredential().Password,

--- a/test/GitHubExtension/GitHubExtension.Test.csproj
+++ b/test/GitHubExtension/GitHubExtension.Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
     <PackageReference Include="Octokit" Version="5.0.4" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
Updates LibGit2Sharp to resolve repository cloning issues on Arm64

## References and relevant issues
#320 
## Detailed description of the pull request / Additional comments
The 0.26.2 version of LibGit2Sharp doesn't contain a native executable for Arm64 which causes cloning to fail. Updating to 0.29.0 results in a successful clone.

## Validation steps performed
After making the changes needed, I ran the dev extension, turned off the store version of the extension, and went through the same process to clone a repository from GitHub.
![image](https://github.com/microsoft/devhomegithubextension/assets/4016293/89a33e07-43d2-4bcb-b5c5-eb1999697499)
![image](https://github.com/microsoft/devhomegithubextension/assets/4016293/429e0f66-2aba-4432-ba3c-db8cc1efb928)

Note: I had to restore the LibGit2Sharp using the NuGet.org package source since 0.29.0 isn't in the DevHomeDependencies source yet.

## PR checklist
- [X] Closes #320 
- [ ] Tests added/passed
- [ ] Documentation updated
