### PR TITLE
Add exception handling to widget state reset

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -69,14 +69,24 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
 
     protected override void ResetWidgetInfoFromState()
     {
-        var dataObject = JsonNode.Parse(ConfigurationData);
-
-        if (dataObject == null)
+        try
         {
-            return;
-        }
+            var dataObject = JsonNode.Parse(ConfigurationData);
 
-        RepositoryUrl = dataObject["url"]?.GetValue<string>() ?? string.Empty;
+            if (dataObject == null)
+            {
+                return;
+            }
+
+            RepositoryUrl = dataObject["url"]?.GetValue<string>() ?? string.Empty;
+        }
+        catch (Exception e)
+        {
+            // If we fail to parse configuration data, do nothing, report the failure, and don't
+            // crash the entire extension.
+            RepositoryUrl = string.Empty;
+            Log.Logger()?.ReportError(Name, ShortId, $"Unexpected error while resetting state: {e.Message}", e);
+        }
     }
 
     public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -57,15 +57,26 @@ internal abstract class GitHubUserWidget : GitHubWidget
 
     protected override void ResetWidgetInfoFromState()
     {
-        var dataObject = JsonNode.Parse(ConfigurationData);
-
-        if (dataObject == null)
+        try
         {
-            return;
-        }
+            var dataObject = JsonNode.Parse(ConfigurationData);
 
-        ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
-        DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
+            if (dataObject == null)
+            {
+                return;
+            }
+
+            ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
+            DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
+        }
+        catch (Exception e)
+        {
+            // If we fail to parse configuration data, do nothing, report the failure, and don't
+            // crash the entire extension.
+            DeveloperLoginId = string.Empty;
+            ShowCategory = SearchCategory.Unknown;
+            Log.Logger()?.ReportError(Name, ShortId, $"Unexpected error while resetting state: {e.Message}", e);
+        }
     }
 
     public override void OnCustomizationRequested(WidgetCustomizationRequestedArgs customizationRequestedArgs)


### PR DESCRIPTION
## Summary of the pull request

Uncaught JSON parse exceptions while resetting state in widgets can crash the extension. This prevents such parse failures from causing the extension to crash.

## References and relevant issues

## Detailed description of the pull request / Additional comments

Adds exception handling on the JSON parsing code in ResetWidgetInfoFromState().

## Validation steps performed

Verified widgets are created/running as expected with the change.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
