### PR TITLE
Add data migration for widgets from string to JSON format

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -76,8 +76,11 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         {
             dataObject = JsonNode.Parse(ConfigurationData);
         }
-        catch (JsonException)
+        catch (JsonException e)
         {
+            Log.Logger()?.ReportWarn(Name, ShortId, $"Failed to parse ConfigurationData; attempting migration. {e.Message}");
+            Log.Logger()?.ReportDebug(Name, ShortId, $"Json parse failure.", e);
+
             // Old data versioning was not a Json string. If we attempt to parse
             // and we get a failure, check if it is the old version.
             if (!string.IsNullOrEmpty(ConfigurationData))

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -71,6 +71,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
     protected override void ResetWidgetInfoFromState()
     {
         JsonNode? dataObject = null;
+
         try
         {
             dataObject = JsonNode.Parse(ConfigurationData);
@@ -79,7 +80,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         {
             // Old data versioning was not a Json string. If we attempt to parse
             // and we get a failure, check if it is the old version.
-            if (Validation.IsValidGitHubURL(ConfigurationData))
+            if (!string.IsNullOrEmpty(ConfigurationData))
             {
                 Log.Logger()?.ReportInfo(Name, ShortId, $"Found string data format, migrating to JSON format. Data: {ConfigurationData}");
                 var migratedState = new JsonObject
@@ -90,7 +91,6 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
             }
             else
             {
-                Log.Logger()?.ReportWarn(Name, ShortId, $"Unrecognized configuration data, setting to default. Data: {ConfigurationData}");
                 ConfigurationData = EmptyJson;
             }
         }

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -81,20 +81,28 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
             Log.Logger()?.ReportWarn(Name, ShortId, $"Failed to parse ConfigurationData; attempting migration. {e.Message}");
             Log.Logger()?.ReportDebug(Name, ShortId, $"Json parse failure.", e);
 
-            // Old data versioning was not a Json string. If we attempt to parse
-            // and we get a failure, check if it is the old version.
-            if (!string.IsNullOrEmpty(ConfigurationData))
+            try
             {
-                Log.Logger()?.ReportInfo(Name, ShortId, $"Found string data format, migrating to JSON format. Data: {ConfigurationData}");
-                var migratedState = new JsonObject
+                // Old data versioning was not a Json string. If we attempt to parse
+                // and we get a failure, check if it is the old version.
+                if (!string.IsNullOrEmpty(ConfigurationData))
                 {
-                    { "url", ConfigurationData },
-                };
-                ConfigurationData = migratedState.ToJsonString();
+                    Log.Logger()?.ReportInfo(Name, ShortId, $"Found string data format, migrating to JSON format. Data: {ConfigurationData}");
+                    var migratedState = new JsonObject
+                    {
+                        { "url", ConfigurationData },
+                    };
+                    ConfigurationData = migratedState.ToJsonString();
+                }
+                else
+                {
+                    ConfigurationData = EmptyJson;
+                }
             }
-            else
+            catch (Exception ex)
             {
-                ConfigurationData = EmptyJson;
+                // Adding for abundance of caution because we have seen crashes in this space.
+                Log.Logger()?.ReportError(Name, ShortId, $"Unexpected failure during migration.", ex);
             }
         }
 

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -64,8 +64,11 @@ internal abstract class GitHubUserWidget : GitHubWidget
         {
             dataObject = JsonNode.Parse(ConfigurationData);
         }
-        catch (JsonException)
+        catch (JsonException e)
         {
+            Log.Logger()?.ReportWarn(Name, ShortId, $"Failed to parse ConfigurationData; attempting migration. {e.Message}");
+            Log.Logger()?.ReportDebug(Name, ShortId, $"Json parse failure.", e);
+
             // Old data versioning was not a Json string. If we attempt to parse
             // and we get a failure, assume it is the old version.
             if (!string.IsNullOrEmpty(ConfigurationData))

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -60,8 +60,6 @@ internal abstract class GitHubUserWidget : GitHubWidget
     {
         JsonNode? dataObject = null;
 
-        ConfigurationData = EnumHelper.SearchCategoryToString(SearchCategory.Issues);
-
         try
         {
             dataObject = JsonNode.Parse(ConfigurationData);
@@ -345,11 +343,11 @@ internal abstract class GitHubUserWidget : GitHubWidget
 
         if (!string.IsNullOrEmpty(DeveloperLoginId))
         {
-            configurationData.Add("account", DeveloperLoginId);
+            configurationData.Add("selectedDevId", DeveloperLoginId);
         }
         else if (DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIds().DeveloperIds.Count() == 1)
         {
-            configurationData.Add("account", DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIds().DeveloperIds.First().LoginId);
+            configurationData.Add("selectedDevId", DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIds().DeveloperIds.First().LoginId);
         }
 
         AddDevIds(ref configurationData);

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -81,6 +81,8 @@ internal abstract class GitHubUserWidget : GitHubWidget
 
                 // Prior to this configuration change, multi-account was not supported. Assume that
                 // if there is exactly one Developer Id that is the one the user had configured.
+                // There is no else case here because if we leave this value absent, the widget will
+                // change state to configuring, where the user can select the developer ID they want.
                 if (DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIds().DeveloperIds.Count() == 1)
                 {
                     migratedState.Add("account", DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIds().DeveloperIds.First().LoginId);


### PR DESCRIPTION
## Summary of the pull request

The multi-account support changes also changed the widget state from a string to a JSON string so we could encode more flexible data. However, existing widget data is still the string format, so to prevent users from losing their widget configuration we needed to add migration code to convert the string format to the JSON string format. This PR adds that for the two categories of widgets, the Repository widget and the User widget.

## References and relevant issues
https://task.ms/48658002

## Detailed description of the pull request / Additional comments

This fix is not a robust migration support feature with data versioning and migrating from version N to version M, which we should absolutely add before making any further data format changes. This change is a rather crude existence check for the old format and changing it to the new format by seeing if it fails JSON parsing and if so, assume it is the old format and convert to the new format. This is a quick fix to unblock the release.

Changes:
* Updated the exception handling when we fail to parse the JSON data to not reset the data to default values, but instead attempt migration if possible.
* In the case of the Repository class of widgets, the old state was a URI string to a repository, so that simply added the repository into the JSON data format and used that instead.
* In the case of the User class of widgets, the old state was a searchCategory string name, so that was converted to the data. In addition, with multi-account support, the User class of widgets also needed a selected devId, which was not data we previously had in these widgets.  This fix assumes that in the event there was exactly one developer id, use that developer id. If there was not one exactly then we would leave that set to the default, which puts the Widget back in the configuration state allowing the user to select which account they wanted to use.

Strongly recommend a future task to add data versioning to the widget data as one of the JSON node values and adding a widget check on creation that compares the current data version to the one the widget expects and to handle any migration if necessary.

## Validation steps performed

* Verified migration scenario by injecting the old string value into the ConfigurationData, which forced the migration code to execute. Confirmed that the code handles that data as-expected for both types of widgets.
* Verified widgets normally work as expected.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
