### PR TITLE
Add Windows toast notifications for new reviews for the logged in developer's pull requests.

### DIFF
--- a/src/GitHubExtension/DataManager/GitHubDataManager.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManager.cs
@@ -543,6 +543,13 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
         // Add/update the review record.
         var newReview = Review.GetOrCreateByOctokitReview(DataStore, octoReview, pullRequest.Id);
 
+        // Ignore comments or pending state.
+        if (string.IsNullOrEmpty(newReview.State) || newReview.State == "Comment")
+        {
+            Log.Logger()?.ReportDebug(Name, "Notifications", $"Ignoring review for {pullRequest}. State: {newReview.State}");
+            return;
+        }
+
         // Create a new notification if the state is different or the review did not exist.
         if (existingReview == null || (existingReview.State != newReview.State))
         {

--- a/src/GitHubExtension/DataManager/GitHubDataManager.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManager.cs
@@ -551,7 +551,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
         var newReview = Review.GetOrCreateByOctokitReview(DataStore, octoReview, pullRequest.Id);
 
         // Ignore comments or pending state.
-        if (string.IsNullOrEmpty(newReview.State) || newReview.State == "Comment")
+        if (string.IsNullOrEmpty(newReview.State) || newReview.State == "Commented")
         {
             Log.Logger()?.ReportDebug(Name, "Notifications", $"Ignoring review for {pullRequest}. State: {newReview.State}");
             return;
@@ -561,7 +561,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
         if (existingReview == null || (existingReview.State != newReview.State))
         {
             // We assume that the logged in developer created this pull request.
-            Log.Logger()?.ReportInfo(Name, "Notifications", $"Creating NewReview Notification for {pullRequest}");
+            Log.Logger()?.ReportInfo(Name, "Notifications", $"Creating NewReview Notification for {pullRequest}. State: {newReview.State}");
             Notification.Create(DataStore, newReview, NotificationType.NewReview);
         }
     }

--- a/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
@@ -47,6 +47,12 @@ public partial class GitHubDataManager
             {
                 notification.ShowToast();
             }
+
+            // Show notifications for new reviews.
+            if (notification.Type == NotificationType.NewReview)
+            {
+                notification.ShowToast();
+            }
         }
     }
 

--- a/src/GitHubExtension/DataModel/DataObjects/Notification.cs
+++ b/src/GitHubExtension/DataModel/DataObjects/Notification.cs
@@ -235,13 +235,27 @@ public class Notification
             var nb = new AppNotificationBuilder();
             nb.SetDuration(AppNotificationDuration.Long);
             nb.AddArgument("htmlurl", HtmlUrl);
-            nb.AddText($"{resLoader.GetString("Notifications_Toast_NewReview/Title")}");
-            nb.AddText($"#{Identifier} - {Title}", new AppNotificationTextProperties().SetMaxLines(1));
+
+            switch (Result)
+            {
+                case "Approved":
+                    nb.AddText($"✅ {resLoader.GetString("Notifications_Toast_NewReview/Approved")}");
+                    break;
+
+                case "ChangesRequested":
+                    nb.AddText($"⚠️ {resLoader.GetString("Notifications_Toast_NewReview/ChangesRequested")}");
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unknown Review Result: {Result}");
+            }
+
+            nb.AddText($"#{Identifier} - {Repository.FullName}", new AppNotificationTextProperties().SetMaxLines(1));
 
             // We want to show Author login but the AppNotification has a max 3 AddText calls, see:
             // https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.appnotifications.builder.appnotificationbuilder.addtext?view=windows-app-sdk-1.2
             // The newline is a workaround to the 3 line restriction to show the Author line.
-            nb.AddText(Result + Environment.NewLine + "@" + User.Login);
+            nb.AddText(Title + Environment.NewLine + "@" + User.Login);
             nb.AddButton(new AppNotificationButton(resLoader.GetString("Notifications_Toast_Button/Dismiss")).AddArgument("action", "dismiss"));
             AppNotificationManager.Default.Show(nb.BuildNotification());
 

--- a/src/GitHubExtension/DataModel/DataObjects/PullRequest.cs
+++ b/src/GitHubExtension/DataModel/DataObjects/PullRequest.cs
@@ -317,6 +317,26 @@ public class PullRequest
         }
     }
 
+    /// <summary>
+    /// Gets all reviews associated with this pull request.
+    /// </summary>
+    [Write(false)]
+    [Computed]
+    public IEnumerable<Review> Reviews
+    {
+        get
+        {
+            if (DataStore == null)
+            {
+                return Enumerable.Empty<Review>();
+            }
+            else
+            {
+                return Review.GetAllForPullRequest(DataStore, this) ?? Enumerable.Empty<Review>();
+            }
+        }
+    }
+
     public override string ToString() => $"{Number}: {Title}";
 
     // Create pull request from OctoKit pull request data

--- a/src/GitHubExtension/DataModel/DataObjects/Review.cs
+++ b/src/GitHubExtension/DataModel/DataObjects/Review.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using Dapper;
+using Dapper.Contrib.Extensions;
+using GitHubExtension.Helpers;
+
+namespace GitHubExtension.DataModel;
+
+[Table("Review")]
+public class Review
+{
+    [Key]
+    public long Id { get; set; } = DataStore.NoForeignKey;
+
+    public long InternalId { get; set; } = DataStore.NoForeignKey;
+
+    // Pull request table
+    public long PullRequestId { get; set; } = DataStore.NoForeignKey;
+
+    // User table
+    public long AuthorId { get; set; } = DataStore.NoForeignKey;
+
+    public string Body { get; set; } = string.Empty;
+
+    public string State { get; set; } = string.Empty;
+
+    public string HtmlUrl { get; set; } = string.Empty;
+
+    public long TimeSubmitted { get; set; } = DataStore.NoForeignKey;
+
+    public long TimeLastObserved { get; set; } = DataStore.NoForeignKey;
+
+    [Write(false)]
+    private DataStore? DataStore
+    {
+        get; set;
+    }
+
+    [Write(false)]
+    [Computed]
+    public DateTime SubmittedAt => TimeSubmitted.ToDateTime();
+
+    [Write(false)]
+    [Computed]
+    public DateTime LastObservedAt => TimeLastObserved.ToDateTime();
+
+    [Write(false)]
+    [Computed]
+    public PullRequest PullRequest
+    {
+        get
+        {
+            if (DataStore == null)
+            {
+                return new PullRequest();
+            }
+            else
+            {
+                return PullRequest.GetById(DataStore, PullRequestId) ?? new PullRequest();
+            }
+        }
+    }
+
+    [Write(false)]
+    [Computed]
+    public User Author
+    {
+        get
+        {
+            if (DataStore == null)
+            {
+                return new User();
+            }
+            else
+            {
+                return User.GetById(DataStore, AuthorId) ?? new User();
+            }
+        }
+    }
+
+    public override string ToString() => $"{PullRequestId}: {AuthorId} - {State}";
+
+    // Create review from OctoKit review data
+    private static Review CreateFromOctokitReview(DataStore dataStore, Octokit.PullRequestReview okitReview, long pullRequestId)
+    {
+        var review = new Review
+        {
+            DataStore = dataStore,
+            InternalId = okitReview.Id,
+            Body = okitReview.Body ?? string.Empty,
+            State = okitReview.State.Value.ToString(),
+            HtmlUrl = okitReview.HtmlUrl ?? string.Empty,
+            TimeSubmitted = okitReview.SubmittedAt.DateTime.ToDataStoreInteger(),
+            TimeLastObserved = DateTime.UtcNow.ToDataStoreInteger(),
+        };
+
+        // Author is a rowid in the User table
+        var author = User.GetOrCreateByOctokitUser(dataStore, okitReview.User);
+        review.AuthorId = author.Id;
+
+        // Repo is a row id in the Repository table.
+        // It is likely the case that we already know the repository id (such as when querying pulls for a repository).
+        if (pullRequestId != DataStore.NoForeignKey)
+        {
+            review.PullRequestId = pullRequestId;
+        }
+
+        return review;
+    }
+
+    private static Review AddOrUpdateReview(DataStore dataStore, Review review)
+    {
+        // Check for existing pull request data.
+        var existingReview = GetByInternalId(dataStore, review.InternalId);
+        if (existingReview is not null)
+        {
+            // Existing pull requests must always be updated to update the LastObserved time.
+            review.Id = existingReview.Id;
+            dataStore.Connection!.Update(review);
+            review.DataStore = dataStore;
+            return review;
+        }
+
+        // No existing pull request, add it.
+        review.Id = dataStore.Connection!.Insert(review);
+        review.DataStore = dataStore;
+        return review;
+    }
+
+    public static Review? GetById(DataStore dataStore, long id)
+    {
+        var review = dataStore.Connection!.Get<Review>(id);
+        if (review is not null)
+        {
+            // Add Datastore so this object can make internal queries.
+            review.DataStore = dataStore;
+        }
+
+        return review;
+    }
+
+    public static Review? GetByInternalId(DataStore dataStore, long internalId)
+    {
+        var sql = @"SELECT * FROM Review WHERE InternalId = @InternalId;";
+        var param = new
+        {
+            InternalId = internalId,
+        };
+
+        var review = dataStore.Connection!.QueryFirstOrDefault<Review>(sql, param, null);
+        if (review is not null)
+        {
+            // Add Datastore so this object can make internal queries.
+            review.DataStore = dataStore;
+        }
+
+        return review;
+    }
+
+    public static Review GetOrCreateByOctokitReview(DataStore dataStore, Octokit.PullRequestReview octokitReview, long repositoryId = DataStore.NoForeignKey)
+    {
+        var newReview = CreateFromOctokitReview(dataStore, octokitReview, repositoryId);
+        return AddOrUpdateReview(dataStore, newReview);
+    }
+
+    public static IEnumerable<Review> GetAllForPullRequest(DataStore dataStore, PullRequest pullRequest)
+    {
+        var sql = @"SELECT * FROM Review WHERE PullRequestId = @PullRequestId ORDER BY TimeSubmitted DESC;";
+        var param = new
+        {
+            PullRequestId = pullRequest.Id,
+        };
+
+        Log.Logger()?.ReportDebug(DataStore.GetSqlLogMessage(sql, param));
+        var reviews = dataStore.Connection!.Query<Review>(sql, param, null) ?? Enumerable.Empty<Review>();
+        foreach (var review in reviews)
+        {
+            review.DataStore = dataStore;
+        }
+
+        return reviews;
+    }
+
+    public static IEnumerable<Review> GetAllForUser(DataStore dataStore, User user)
+    {
+        var sql = @"SELECT * FROM Review WHERE AuthorId = @AuthorId;";
+        var param = new
+        {
+            AuthorId = user.Id,
+        };
+
+        Log.Logger()?.ReportDebug(DataStore.GetSqlLogMessage(sql, param));
+        var reviews = dataStore.Connection!.Query<Review>(sql, param, null) ?? Enumerable.Empty<Review>();
+        foreach (var review in reviews)
+        {
+            review.DataStore = dataStore;
+        }
+
+        return reviews;
+    }
+
+    public static void DeleteUnreferenced(DataStore dataStore)
+    {
+        // Delete any reviews that have no matching PullRequestId in the PullRequest table.
+        var sql = @"DELETE FROM Review WHERE PullRequestId NOT IN (SELECT Id FROM PullRequest)";
+        var command = dataStore.Connection!.CreateCommand();
+        command.CommandText = sql;
+        Log.Logger()?.ReportDebug(DataStore.GetCommandLogMessage(sql, command));
+        var rowsDeleted = command.ExecuteNonQuery();
+        Log.Logger()?.ReportDebug(DataStore.GetDeletedLogMessage(rowsDeleted));
+    }
+}

--- a/src/GitHubExtension/DataModel/Enums/NotificationType.cs
+++ b/src/GitHubExtension/DataModel/Enums/NotificationType.cs
@@ -8,4 +8,5 @@ public enum NotificationType
     Unknown = 0,
     CheckRunFailed = 1,
     CheckRunSucceeded = 2,
+    NewReview = 3,
 }

--- a/src/GitHubExtension/DataModel/GitHubDataStoreSchema.cs
+++ b/src/GitHubExtension/DataModel/GitHubDataStoreSchema.cs
@@ -13,7 +13,7 @@ public class GitHubDataStoreSchema : IDataStoreSchema
     }
 
     // Update this anytime incompatible changes happen with a released version.
-    private const long SchemaVersionValue = 0x0005;
+    private const long SchemaVersionValue = 0x0006;
 
     private static readonly string Metadata =
     @"CREATE TABLE Metadata (" +
@@ -233,6 +233,20 @@ public class GitHubDataStoreSchema : IDataStoreSchema
     ");" +
     "CREATE UNIQUE INDEX IDX_SearchIssue_SearchIssue ON SearchIssue (Search, Issue);";
 
+    private static readonly string Review =
+    @"CREATE TABLE Review (" +
+        "Id INTEGER PRIMARY KEY NOT NULL," +
+        "InternalId INTEGER NOT NULL," +
+        "PullRequestId INTEGER NOT NULL," +
+        "AuthorId INTEGER NOT NULL," +
+        "Body TEXT NOT NULL COLLATE NOCASE," +
+        "State TEXT NOT NULL COLLATE NOCASE," +
+        "HtmlUrl TEXT NULL COLLATE NOCASE," +
+        "TimeSubmitted INTEGER NOT NULL," +
+        "TimeLastObserved INTEGER NOT NULL" +
+    ");" +
+    "CREATE UNIQUE INDEX IDX_Review_InternalId ON Review (InternalId);";
+
     // All Sqls together.
     private static readonly List<string> SchemaSqlsValue = new ()
     {
@@ -253,5 +267,6 @@ public class GitHubDataStoreSchema : IDataStoreSchema
         Notification,
         Search,
         SearchIssue,
+        Review,
     };
 }

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -501,8 +501,12 @@
     <value>Please enter the PAT</value>
     <comment>LoginUI Error text if input is null</comment>
   </data>
-  <data name="Notifications_Toast_NewReview.Title" xml:space="preserve">
-    <value>New review</value>
+  <data name="Notifications_Toast_NewReview.Approved" xml:space="preserve">
+    <value>Approved</value>
+    <comment>Shown in toast notification.</comment>
+  </data>
+  <data name="Notifications_Toast_NewReview.ChangesRequested" xml:space="preserve">
+    <value>Changes requested</value>
     <comment>Shown in toast notification.</comment>
   </data>
 </root>

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -501,4 +501,8 @@
     <value>Please enter the PAT</value>
     <comment>LoginUI Error text if input is null</comment>
   </data>
+  <data name="Notifications_Toast_NewReview.Title" xml:space="preserve">
+    <value>New review</value>
+    <comment>Shown in toast notification.</comment>
+  </data>
 </root>

--- a/test/GitHubExtension/DataStore/DataObjectTests.cs
+++ b/test/GitHubExtension/DataStore/DataObjectTests.cs
@@ -529,4 +529,70 @@ public partial class DataStoreTests
         testListener.PrintEventCounts();
         Assert.AreEqual(false, testListener.FoundErrors());
     }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ReadAndWriteReview()
+    {
+        using var log = new Logger("TestStore", TestOptions.LogOptions);
+        var testListener = new TestListener("TestListener", TestContext!);
+        log.AddListener(testListener);
+        Log.Attach(log);
+
+        using var dataStore = new DataStore("TestStore", TestHelpers.GetDataStoreFilePath(TestOptions), TestOptions.DataStoreOptions.DataStoreSchema!);
+        Assert.IsNotNull(dataStore);
+        dataStore.Create();
+        Assert.IsNotNull(dataStore.Connection);
+
+        using var tx = dataStore.Connection!.BeginTransaction();
+
+        var reviews = new List<Review>
+        {
+            { new Review { PullRequestId = 1, AuthorId = 2, Body = "Review 1", InternalId = 16, State = "Approved" } },
+            { new Review { PullRequestId = 1, AuthorId = 3, Body = "Review 2", InternalId = 47, State = "Rejected" } },
+        };
+
+        dataStore.Connection.Insert(reviews[0]);
+        dataStore.Connection.Insert(reviews[1]);
+
+        // Add User record
+        dataStore.Connection.Insert(new User { Login = "Kittens", InternalId = 6, AvatarUrl = "https://www.microsoft.com", Type = "Cat" });
+        dataStore.Connection.Insert(new User { Login = "Doggos", InternalId = 83, AvatarUrl = "https://www.microsoft.com", Type = "Dog" });
+        dataStore.Connection.Insert(new User { Login = "Lizards", InternalId = 3, AvatarUrl = "https://www.microsoft.com", Type = "Reptile" });
+
+        // Add repository record
+        dataStore.Connection.Insert(new Repository { OwnerId = 1, InternalId = 47, Name = "TestRepo1", Description = "Short Desc", HtmlUrl = "https://www.microsoft.com", DefaultBranch = "main", HasIssues = 1 });
+
+        // Add PullRequest record
+        dataStore.Connection.Insert(new PullRequest { Title = "Fix the things", InternalId = 42, HeadSha = "1234abcd", AuthorId = 1, RepositoryId = 1 });
+
+        tx.Commit();
+
+        // Verify retrieval and input into data objects.
+        var dataStoreReviews = dataStore.Connection.GetAll<Review>().ToList();
+        Assert.AreEqual(2, dataStoreReviews.Count);
+        foreach (var review in dataStoreReviews)
+        {
+            TestContext?.WriteLine($"  Review: {review.Id}: {review.Body} - {review.State}");
+
+            Assert.IsTrue(review.Id == 1 || review.Id == 2);
+            Assert.AreEqual(review.Body, $"Review {review.Id}");
+            Assert.IsTrue(review.AuthorId == review.Id + 1);
+        }
+
+        // Verify objects work.
+        var pullrequest = PullRequest.GetById(dataStore, 1);
+        Assert.IsNotNull(pullrequest);
+        var reviewsForPullRequest = pullrequest.Reviews;
+        Assert.IsNotNull(reviewsForPullRequest);
+        Assert.AreEqual(2, reviewsForPullRequest.Count());
+        foreach (var review in reviewsForPullRequest)
+        {
+            TestContext?.WriteLine($"  PR 1 - Review: {review}");
+            Assert.IsTrue(review.PullRequestId == 1);
+        }
+
+        testListener.PrintEventCounts();
+        Assert.AreEqual(false, testListener.FoundErrors());
+    }
 }

--- a/test/GitHubExtension/DataStore/DataObjectTests.cs
+++ b/test/GitHubExtension/DataStore/DataObjectTests.cs
@@ -515,8 +515,7 @@ public partial class DataStoreTests
         Assert.AreEqual(1, prStatus.ConclusionId);
 
         // Create notification from PR Status
-        var notification = DataModel.Notification.Create(prStatus, NotificationType.CheckRunFailed);
-        notification = DataModel.Notification.Add(dataStore, notification);
+        var notification = Notification.Create(dataStore, prStatus, NotificationType.CheckRunFailed);
         Assert.IsNotNull(notification);
         Assert.AreEqual("Fix the things", notification.Title);
         Assert.AreEqual(1, notification.RepositoryId);


### PR DESCRIPTION
## Summary of the pull request

This pull request adds support for sending Windows toast notifications when a review is submitted for one of the logged in developer's pull requests. Only reviews of type "Approved" or "Changes Requested" have notifications associated with them.

![Screenshot 2024-02-02 145107](https://github.com/microsoft/devhomegithubextension/assets/18407763/7bfbe978-14cb-4d4b-af37-98ae6a8d4fc5)

While we cannot get the status of when something is ready-to-merge without admin access to a repository, we can know when a new review is added, and whether anyone reviewing is approving or requesting changes. In most realistic scenarios, such a review notification, along with Check failure notifications, will indicate when a PR needs attention, either for completing it, making changes, or fixing failed check runs. While an "Approved" review may not be all that is required to complete a PR, it is possible that it is the last thing required and so it is a relevant notification that the PR may be ready for merging. A "Changes Requested" notification is a definite indicator that the PR needs attention.


## References and relevant issues

Closes #297 
Closes #298

This does not address all requests in the above issues, but it does reflect what we intend to do with GitHub notifications at this time.

## Detailed description of the pull request / Additional comments

These new notifications are tied to the notifications setting for the extension, so disabling the notification setting will also disable these new notifications.

Only reviews for pull requests for the logged in developer accounts are tracked and have notifications. Reviews for other PRs in watched repositories are ignored.

Reviews discovered that are older than 7 days will be treated as stale and ignored. This is to avoid notification spam when the extension is updated with this feature and all outstanding PRs with reviews suddenly create notifications. In this case only relatively recent review notifications will be created for outstanding PRs. The time span of 7 days was chosen so if people don't run Dev Home for a few days and then launch it again they will see these notifications for reviews of outstanding PRs that are still open.

This update also adds support for marking older notifications for the same repository+user+pullrequest as toasted when a new notification is encountered if they have not yet been toasted. This is so if a reviewer were to change their review (from Changes Requested to Approved, for example) between times this extension checks for reviews the user will not see notifications for both events. Instead, they will only see the most recent notification for that pull request and user review.
 
At a lower level this change updates the datastore to start tracking reviews for active pull requests and includes a schema update. As a new data object was added, corresponding data object tests were also added.

## Validation steps performed

* Verified new review data object tests pass.
* Verified updated notification test passes.
* Verified review notifications show for Approved and Changes Requested with several pull requests and reviews.
* Verified that multiple notifications for the same pull request and user is correctly only showing the most recent notification.
* Verified reviews older than the stale time are not included in the notifications.
* Verified that if a reviewer changes their vote from "Changes Requested" to "Approved" (or vice-versa) that a new notification is created.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
