### PR TITLE
Add select account placeholder text in widgets

### DIFF
--- a/src/GitHubExtension/Helpers/Resources.cs
+++ b/src/GitHubExtension/Helpers/Resources.cs
@@ -101,6 +101,7 @@ public static class Resources
             "Widget_Template_Button/Cancel",
             "Widget_Template_Tooltip/Save",
             "Widget_Template_Tooltip/Cancel",
+            "Widget_Template/ChooseAccountPlaceholder",
         };
     }
 }

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -509,4 +509,8 @@
     <value>Changes requested</value>
     <comment>Shown in toast notification.</comment>
   </data>
+  <data name="Widget_Template.ChooseAccountPlaceholder" xml:space="preserve">
+    <value>Please choose an account</value>
+    <comment>Placeholder text for a combobox where the user can select between accounts</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Actual text was missing.

Old and new:
![image](https://github.com/microsoft/devhomegithubextension/assets/47155823/04c413a1-b3ac-4d05-b16b-87c1fdec8ea6)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
