### PR TITLE
bump winappsdk to 1.5

### DIFF
--- a/src/GitHubExtension/GitHubExtension.csproj
+++ b/src/GitHubExtension/GitHubExtension.csproj
@@ -79,8 +79,8 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.369" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.418" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="10.0.0" />
   </ItemGroup>

--- a/src/GitHubExtension/GitHubExtension.csproj
+++ b/src/GitHubExtension/GitHubExtension.csproj
@@ -80,7 +80,7 @@
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.369" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="10.0.0" />
   </ItemGroup>

--- a/src/GitHubExtension/GitHubExtension.csproj
+++ b/src/GitHubExtension/GitHubExtension.csproj
@@ -79,8 +79,8 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.418" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.369" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="10.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of the pull request

Upgrade to 1.5 winappsdk, intentionally doesn't include devhome sdk upgrade

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
