### PR TITLE
Widgets now have custom Titles

### DIFF
--- a/src/GitHubExtension/Helpers/Resources.cs
+++ b/src/GitHubExtension/Helpers/Resources.cs
@@ -105,6 +105,8 @@ public static class Resources
             "Widget_Template/ChooseAccountPlaceholder",
             "Widget_Template/Published",
             "Widget_Template_Tooltip/OpenRelease",
+            "Widget_Template/WidgetTitleLabel",
+            "Widget_Template/WidgetTitlePlaceholder",
         };
     }
 }

--- a/src/GitHubExtension/Strings/en-US/Resources.resw
+++ b/src/GitHubExtension/Strings/en-US/Resources.resw
@@ -533,4 +533,12 @@
     <value>There are no releases in this repository.</value>
     <comment>Shown in Widget, when there are no releases</comment>
   </data>
+  <data name="Widget_Template/WidgetTitleLabel" xml:space="preserve">
+    <value>Title (Optional)</value>
+    <comment>Shown in Widget, Label for title</comment>
+  </data>
+  <data name="Widget_Template/WidgetTitlePlaceholder" xml:space="preserve">
+    <value>Widget Title</value>
+    <comment>Shown in Widget, placeholder for title</comment>
+  </data>
 </root>

--- a/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
@@ -154,6 +154,7 @@ internal class GitHubIssuesWidget : GitHubRepositoryWidget
 
             issuesData.Add("issues", issuesArray);
             issuesData.Add("selected_repo", repository?.FullName ?? string.Empty);
+            issuesData.Add("widgetTitle", WidgetTitle);
             issuesData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
             issuesData.Add("issues_icon_data", issuesIconData);
 

--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -127,6 +127,7 @@ internal class GitHubPullsWidget : GitHubRepositoryWidget
 
             pullsData.Add("pulls", pullsArray);
             pullsData.Add("selected_repo", repository?.FullName ?? string.Empty);
+            pullsData.Add("widgetTitle", WidgetTitle);
             pullsData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
             pullsData.Add("pulls_icon_data", pullsIconData);
 

--- a/src/GitHubExtension/Widgets/GitHubReleasesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReleasesWidget.cs
@@ -124,6 +124,7 @@ internal class GitHubReleasesWidget : GitHubRepositoryWidget
 
             releasesData.Add("releases", releasesArray);
             releasesData.Add("selected_repo", repository?.FullName ?? string.Empty);
+            releasesData.Add("widgetTitle", WidgetTitle);
             releasesData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
             releasesData.Add("releases_icon_data", _releasesIconData);
 

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -59,6 +59,11 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
                 HandleCheckUrl(actionInvokedArgs);
                 break;
 
+            case WidgetAction.Save:
+                UpdateTitle(JsonNode.Parse(actionInvokedArgs.Data));
+                base.OnActionInvoked(actionInvokedArgs);
+                break;
+
             default:
                 base.OnActionInvoked(actionInvokedArgs);
                 break;
@@ -117,8 +122,13 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         return repository;
     }
 
-    private void UpdateTitle(JsonNode dataObj)
+    private void UpdateTitle(JsonNode? dataObj)
     {
+        if (dataObj == null)
+        {
+            return;
+        }
+
         GetTitleFromDataObject(dataObj);
         if (WidgetTitle == string.Empty)
         {

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -117,6 +117,15 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         return repository;
     }
 
+    private void UpdateTitle(JsonNode dataObj)
+    {
+        GetTitleFromDataObject(dataObj);
+        if (WidgetTitle == string.Empty)
+        {
+            WidgetTitle = GetRepositoryFromUrl(RepositoryUrl).FullName;
+        }
+    }
+
     protected override void ResetWidgetInfoFromState()
     {
         JsonNode? dataObject = null;
@@ -159,6 +168,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         {
             dataObject ??= JsonNode.Parse(ConfigurationData);
             RepositoryUrl = dataObject!["url"]?.GetValue<string>() ?? string.Empty;
+            UpdateTitle(dataObject);
         }
         catch (Exception e)
         {
@@ -189,6 +199,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         if (dataObject != null && dataObject["url"] != null)
         {
             RepositoryUrl = dataObject["url"]?.GetValue<string>() ?? string.Empty;
+            UpdateTitle(dataObject);
 
             ConfigurationData = data;
 
@@ -208,6 +219,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         var configurationData = new JsonObject
         {
             { "submitIcon", IconLoader.GetIconAsBase64("arrow.png") },
+            { "widgetTitle", WidgetTitle },
         };
 
         if (dataUrl == string.Empty)

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -130,7 +130,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         }
 
         GetTitleFromDataObject(dataObj);
-        if (WidgetTitle == string.Empty)
+        if (string.IsNullOrEmpty(WidgetTitle))
         {
             WidgetTitle = GetRepositoryFromUrl(RepositoryUrl).FullName;
         }

--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -54,6 +54,7 @@ internal class GitHubReviewWidget : GitHubUserWidget
             }
 
             DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
+            UpdateTitle(dataObject);
 
             ConfigurationData = data;
 

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -64,8 +64,6 @@ internal abstract class GitHubUserWidget : GitHubWidget
         {
             WidgetTitle = UserName;
         }
-
-        Log.Logger()?.ReportInfo("Depois do update = " + WidgetTitle);
     }
 
     protected override void ResetWidgetInfoFromState()

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -60,7 +60,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
     protected void UpdateTitle(JsonNode dataObj)
     {
         GetTitleFromDataObject(dataObj);
-        if (WidgetTitle == string.Empty)
+        if (string.IsNullOrEmpty(WidgetTitle))
         {
             WidgetTitle = UserName;
         }

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -57,6 +57,17 @@ internal abstract class GitHubUserWidget : GitHubWidget
         UpdateActivityState();
     }
 
+    protected void UpdateTitle(JsonNode dataObj)
+    {
+        GetTitleFromDataObject(dataObj);
+        if (WidgetTitle == string.Empty)
+        {
+            WidgetTitle = UserName;
+        }
+
+        Log.Logger()?.ReportInfo("Depois do update = " + WidgetTitle);
+    }
+
     protected override void ResetWidgetInfoFromState()
     {
         JsonNode? dataObject = null;
@@ -110,6 +121,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             dataObject ??= JsonNode.Parse(ConfigurationData);
             ShowCategory = EnumHelper.StringToSearchCategory(dataObject!["showCategory"]?.GetValue<string>() ?? string.Empty);
             DeveloperLoginId = dataObject!["account"]?.GetValue<string>() ?? string.Empty;
+            UpdateTitle(dataObject);
         }
         catch (Exception e)
         {
@@ -141,6 +153,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
 
             ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
             DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
+            UpdateTitle(dataObject);
 
             ConfigurationData = data;
 
@@ -240,6 +253,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             { "openCount", 0 },
             { "items", new JsonArray() },
             { "userName", UserName },
+            { "widgetTitle", WidgetTitle },
             { "titleIconUrl", GetTitleIconData() },
             { "is_loading_data", true },
         };
@@ -292,6 +306,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             issuesData.Add("items", issuesArray);
             issuesData.Add("userName", UserName);
             issuesData.Add("titleIconUrl", GetTitleIconData());
+            issuesData.Add("widgetTitle", WidgetTitle);
 
             LastUpdated = DateTime.Now;
             ContentData = issuesData.ToJsonString();
@@ -353,6 +368,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             { "showCategory", EnumHelper.SearchCategoryToString(ShowCategory == SearchCategory.Unknown ? SearchCategory.IssuesAndPullRequests : ShowCategory) },
             { "savedShowCategory", SavedConfigurationData },
             { "configuring", true },
+            { "widgetTitle", WidgetTitle },
         };
 
         if (!string.IsNullOrEmpty(DeveloperLoginId))

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -170,7 +170,6 @@ public abstract class GitHubWidget : WidgetImpl
     protected void GetTitleFromDataObject(JsonNode dataObj)
     {
         WidgetTitle = dataObj!["widgetTitle"]?.GetValue<string>() ?? string.Empty;
-        Log.Logger()?.ReportInfo("Widget Title = " + WidgetTitle);
     }
 
     private async Task HandleSignIn()

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -45,6 +45,8 @@ public abstract class GitHubWidget : WidgetImpl
 
     protected string SavedConfigurationData { get; set; } = string.Empty;
 
+    protected string WidgetTitle { get; set; } = string.Empty;
+
     protected DateTime LastUpdated { get; set; } = DateTime.MinValue;
 
     protected DataUpdater DataUpdater { get; set; }
@@ -163,6 +165,12 @@ public abstract class GitHubWidget : WidgetImpl
         SavedConfigurationData = ConfigurationData;
         Saved = false;
         SetConfigure();
+    }
+
+    protected void GetTitleFromDataObject(JsonNode dataObj)
+    {
+        WidgetTitle = dataObj!["widgetTitle"]?.GetValue<string>() ?? string.Empty;
+        Log.Logger()?.ReportInfo("Widget Title = " + WidgetTitle);
     }
 
     private async Task HandleSignIn()

--- a/src/GitHubExtension/Widgets/Templates/GitHubAssignedConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubAssignedConfigurationTemplate.json
@@ -17,6 +17,13 @@
       ]
     },
     {
+      "type": "Input.Text",
+      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
+      "id": "widgetTitle",
+      "label": "%Widget_Template/WidgetTitleLabel%",
+      "value": "${widgetTitle}"
+    },
+    {
       "type": "ColumnSet",
       "columns": [
         {

--- a/src/GitHubExtension/Widgets/Templates/GitHubAssignedTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubAssignedTemplate.json
@@ -22,7 +22,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "${userName}",
+              "text": "${widgetTitle}",
               "size": "Large",
               "style": "Heading",
               "wrap": true

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
@@ -19,6 +19,13 @@
       "value": "${$root.configuration.url}"
     },
     {
+      "type": "Input.Text",
+      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
+      "id": "widgetTitle",
+      "label": "%Widget_Template/WidgetTitleLabel%",
+      "value": "${widgetTitle}"
+    },
+    {
       "type": "Container",
       "items": [
         {
@@ -85,13 +92,6 @@
       "$when": "${$root.hasConfiguration}",
       "horizontalAlignment": "Left",
       "bleed": true
-    },
-    {
-      "type": "Input.Text",
-      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
-      "id": "widgetTitle",
-      "label": "%Widget_Template/WidgetTitleLabel%",
-      "value": "${widgetTitle}"
     },
     {
       "type": "ColumnSet",

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
@@ -87,6 +87,13 @@
       "bleed": true
     },
     {
+      "type": "Input.Text",
+      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
+      "id": "widgetTitle",
+      "label": "%Widget_Template/WidgetTitleLabel%",
+      "value": "${widgetTitle}"
+    },
+    {
       "type": "ColumnSet",
       "spacing": "Medium",
       "columns": [

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesTemplate.json
@@ -24,7 +24,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "${selected_repo}",
+              "text": "${widgetTitle}",
               "size": "large",
               "style": "heading",
               "wrap": true

--- a/src/GitHubExtension/Widgets/Templates/GitHubMentionedInConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubMentionedInConfigurationTemplate.json
@@ -17,6 +17,13 @@
       ]
     },
     {
+      "type": "Input.Text",
+      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
+      "id": "widgetTitle",
+      "label": "%Widget_Template/WidgetTitleLabel%",
+      "value": "${widgetTitle}"
+    },
+    {
       "type": "ColumnSet",
       "columns": [
         {

--- a/src/GitHubExtension/Widgets/Templates/GitHubMentionedInTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubMentionedInTemplate.json
@@ -22,7 +22,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "${userName}",
+              "text": "${widgetTitle}",
               "size": "Large",
               "style": "Heading",
               "wrap": true

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -19,6 +19,13 @@
       "value": "${$root.configuration.url}"
     },
     {
+      "type": "Input.Text",
+      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
+      "id": "widgetTitle",
+      "label": "%Widget_Template/WidgetTitleLabel%",
+      "value": "${widgetTitle}"
+    },
+    {
       "type": "Container",
       "items": [
         {

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsTemplate.json
@@ -24,7 +24,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "${selected_repo}",
+              "text": "${widgetTitle}",
               "size": "large",
               "style": "heading",
               "wrap": true

--- a/src/GitHubExtension/Widgets/Templates/GitHubReleasesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubReleasesConfigurationTemplate.json
@@ -19,6 +19,13 @@
       "value": "${$root.configuration.url}"
     },
     {
+      "type": "Input.Text",
+      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
+      "id": "widgetTitle",
+      "label": "%Widget_Template/WidgetTitleLabel%",
+      "value": "${widgetTitle}"
+    },
+    {
       "type": "Container",
       "items": [
         {

--- a/src/GitHubExtension/Widgets/Templates/GitHubReleasesTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubReleasesTemplate.json
@@ -24,7 +24,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "${selected_repo}",
+              "text": "${widgetTitle}",
               "size": "large",
               "style": "heading",
               "wrap": true

--- a/src/GitHubExtension/Widgets/Templates/GitHubReviewConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubReviewConfigurationTemplate.json
@@ -17,6 +17,13 @@
       ]
     },
     {
+      "type": "Input.Text",
+      "placeholder": "%Widget_Template/WidgetTitlePlaceholder%",
+      "id": "widgetTitle",
+      "label": "%Widget_Template/WidgetTitleLabel%",
+      "value": "${widgetTitle}"
+    },
+    {
       "type": "ColumnSet",
       "columns": [
         {

--- a/src/GitHubExtension/Widgets/Templates/GitHubReviewTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubReviewTemplate.json
@@ -22,7 +22,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "${userName}",
+              "text": "${widgetTitle}",
               "size": "Large",
               "style": "Heading",
               "wrap": true


### PR DESCRIPTION
## Summary of the pull request
This pull request adds the possibility of having custom titles on the Github widgets, the same functionality already existing in the Azure widgets.

For this, on the widget configuration of each widget, there is now an optional field _Title_ that can be filled in.
![image](https://github.com/microsoft/devhomegithubextension/assets/13912953/c2b8483a-4bd0-4036-9ccc-f0a6739a11f5) 
![image](https://github.com/microsoft/devhomegithubextension/assets/13912953/b04ca42e-5c37-45e2-b2d1-325288b69645)

This field, if not filled out, will result on titles in the same way it was before (Dev IDs for the _User Widgets_, and repository full name for the _Repository Widgets_).

We can then set the text we want, and when clicking either **Submit** or **Save**, it will be set as the new title.

![image](https://github.com/microsoft/devhomegithubextension/assets/13912953/5ad36ba9-caa3-4269-b2c5-b09e7cc74b68)

And this title can be changed when customizing the widget after creating it.

![image](https://github.com/microsoft/devhomegithubextension/assets/13912953/72f81371-6289-4210-a15d-263845994faa)


## References and relevant issues

## Detailed description of the pull request / Additional comments

For this PR, was added a new property `WidgetTitle` to the class `GithubWidget`, as all the widgets are intended to have a editable title. This title is passed to the widget via a usual input on the widget configuration, and this class have a method to retrieve this information from the data object created from the data string.

Then, the `GitHubUserWidget` and `GitHubRepositoryWidget` both have methods to update the title, and setting it to a default value if it was not provided by the user.

Each template was changed to present the `widgetTitle` data as the title.

On the widgets code, the Title is update whenever an action of _ Submit_ or _Save_ is invoked.


## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
