### PR TITLE
Probing for the enterprise server

### DIFF
--- a/src/GitHubExtension/Client/Validation.cs
+++ b/src/GitHubExtension/Client/Validation.cs
@@ -22,7 +22,7 @@ public static class Validation
 
     public static bool IsValidGitHubURL(Uri uri)
     {
-        return IsValidGitHubComURL(uri) || IsValidGitHubEnterpriseServerURL(uri);
+        return IsValidGitHubComURL(uri) || (IsValidGitHubEnterpriseServerURL(uri) && IsReachableGitHubEnterpriseServerURL(uri).Result);
     }
 
     public static bool IsValidGitHubComURL(Uri uri)


### PR DESCRIPTION
## Summary of the pull request
The extension gives a false positive if a non-GitHub Url with 3 segments is put into the URL text box.  This is because of the || condition.  How the extension checks if the github URL is valid is
1. Is the host not either www.github.com or github.com and is the segment count < 3
2. Is the segment count less than 3 (For enterprise servers)

A bitbucket URL would give false positive because check 1 returns false and check 2 returns true.  ||'s these together and the result is true.

Added an additional check to make sure the server can be probed.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually ran.

Task: https://task.ms/49116620

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movies!
Before the fix!
![BitBucketBeforeFix](https://github.com/microsoft/devhomegithubextension/assets/2517139/ffbd96a7-20a8-485f-994d-c18982478e3a)

After the fix!
![BitBucketAfterFix](https://github.com/microsoft/devhomegithubextension/assets/2517139/88c2f52b-ae50-4f4a-8dc3-2811e5de29a6)

