### PR TITLE
Fix timestamp log format

### DIFF
--- a/src/GitHubExtensionServer/appsettings.json
+++ b/src/GitHubExtensionServer/appsettings.json
@@ -6,7 +6,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -14,7 +14,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\log.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }

--- a/test/Console/appsettings.json
+++ b/test/Console/appsettings.json
@@ -6,7 +6,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -14,7 +14,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\log.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }

--- a/test/GitHubExtension/Helpers/TestSetupHelpers.cs
+++ b/test/GitHubExtension/Helpers/TestSetupHelpers.cs
@@ -77,11 +77,11 @@ public partial class TestHelpers
             .WriteTo.File(
                 path: GetLogFilePath(options),
                 formatProvider: CultureInfo.InvariantCulture,
-                outputTemplate: "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
+                outputTemplate: "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
             .WriteTo.TestContextSink(
                 context: context,
                 formatProvider: CultureInfo.InvariantCulture,
-                outputTemplate: "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
+                outputTemplate: "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}")
             .CreateLogger();
     }
 


### PR DESCRIPTION
## Summary of the pull request
Timestamp format was incorrect for the logging, putting minutes instead of months and creating an invalid timestamp. It also fails to parse as a DateTime which broke tooling.

## References and relevant issues
Closes #376 

## Detailed description of the pull request / Additional comments
* Fixed output format to use correct format specifier for Month.

## Validation steps performed
* Verified log format is correct with the fix.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
