### PR TITLE
Fix exception logging

### DIFF
--- a/src/GitHubExtension/Client/GithubClientProvider.cs
+++ b/src/GitHubExtension/Client/GithubClientProvider.cs
@@ -94,7 +94,7 @@ public class GitHubClientProvider
             }
             catch (Exception ex)
             {
-                Log.Error($"Rate limiting not enabled for server.", ex);
+                Log.Error(ex, $"Rate limiting not enabled for server.");
             }
         }
 

--- a/src/GitHubExtension/Client/Validation.cs
+++ b/src/GitHubExtension/Client/Validation.cs
@@ -238,7 +238,7 @@ public static class Validation
         }
         catch (Exception ex)
         {
-            Log.Error($"EnterpriseServer {server.AbsoluteUri} could not be probed.", ex);
+            Log.Error(ex, $"EnterpriseServer {server.AbsoluteUri} could not be probed.");
             return false;
         }
 

--- a/src/GitHubExtension/DataManager/GitHubDataManager.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManager.cs
@@ -47,7 +47,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
         }
         catch (Exception e)
         {
-            Log.Error("Failed creating GitHubDataManager", e);
+            Log.Error(e, "Failed creating GitHubDataManager");
             Environment.FailFast(e.Message, e);
             return null;
         }
@@ -253,7 +253,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed Updating DataStore for: {parameters}", ex);
+            Log.Error(ex, $"Failed Updating DataStore for: {parameters}");
             tx.Rollback();
 
             // Rethrow so clients can catch/display an error UX.
@@ -334,7 +334,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
         catch (Exception ex)
         {
             // This is for catching any other unexpected error as well as any we throw.
-            Log.Error($"Failed trying update data for repository: {parameters.Owner}/{parameters.RepositoryName}", ex);
+            Log.Error(ex, $"Failed trying update data for repository: {parameters.Owner}/{parameters.RepositoryName}");
             tx.Rollback();
             throw;
         }
@@ -460,7 +460,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
                         Log.Error($"Error updating Check Status for Pull Request #{octoPull.Number}: {e.Message}");
 
                         // Put the full stack trace in debug if this occurs to reduce log spam.
-                        Log.Debug($"Error updating Check Status for Pull Request #{octoPull.Number}.", e);
+                        Log.Debug(e, $"Error updating Check Status for Pull Request #{octoPull.Number}.");
                     }
 
                     var commitCombinedStatus = await devId.GitHubClient.Repository.Status.GetCombined(dsRepository.InternalId, dsPullRequest.HeadSha);
@@ -486,7 +486,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
                         Log.Error($"Error updating Reviews for Pull Request #{octoPull.Number}: {e.Message}");
 
                         // Put the full stack trace in debug if this occurs to reduce log spam.
-                        Log.Debug($"Error updating Reviews for Pull Request #{octoPull.Number}.", e);
+                        Log.Debug(e, $"Error updating Reviews for Pull Request #{octoPull.Number}.");
                     }
                 }
 
@@ -551,7 +551,7 @@ public partial class GitHubDataManager : IGitHubDataManager, IDisposable
                 Log.Error($"Error updating Check Status for Pull Request #{pull.Number}: {e.Message}");
 
                 // Put the full stack trace in debug if this occurs to reduce log spam.
-                Log.Debug($"Error updating Check Status for Pull Request #{pull.Number}.", e);
+                Log.Debug(e, $"Error updating Check Status for Pull Request #{pull.Number}.");
             }
 
             var commitCombinedStatus = await client.Repository.Status.GetCombined(repository.InternalId, dsPullRequest.HeadSha);

--- a/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
@@ -27,7 +27,7 @@ public partial class GitHubDataManager
         }
         catch (Exception ex)
         {
-            Log.Error("Update failed unexpectedly.", ex);
+            Log.Error(ex, "Update failed unexpectedly.");
         }
 
         lastUpdateTime = DateTime.Now;

--- a/src/GitHubExtension/DataManager/GitHubSearchManger.cs
+++ b/src/GitHubExtension/DataManager/GitHubSearchManger.cs
@@ -33,7 +33,7 @@ public partial class GitHubSearchManager : IGitHubSearchManager, IDisposable
         }
         catch (Exception e)
         {
-            Log.Error(Name, "Failed creating GitHubSearchManager", e);
+            Log.Error(e, "Failed creating GitHubSearchManager");
             Environment.FailFast(e.Message, e);
             return null;
         }

--- a/src/GitHubExtension/DataModel/DataObjects/Notification.cs
+++ b/src/GitHubExtension/DataModel/DataObjects/Notification.cs
@@ -98,7 +98,7 @@ public class Notification
                     // Catch errors so we do not throw for something like this. The local ToastState
                     // will still be set even if the datastore update fails. This could result in a
                     // toast later being shown twice, however, so report it as an error.
-                    Log.Error("Failed setting Notification ToastState for Notification Id = {Id}", ex);
+                    Log.Error(ex, "Failed setting Notification ToastState for Notification Id = {Id}");
                 }
             }
         }
@@ -194,7 +194,7 @@ public class Notification
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed creating the Notification for {this}", ex);
+            Log.Error(ex, $"Failed creating the Notification for {this}");
             return false;
         }
 
@@ -224,7 +224,7 @@ public class Notification
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed creating the Notification for {this}", ex);
+            Log.Error(ex, $"Failed creating the Notification for {this}");
             return false;
         }
 
@@ -267,7 +267,7 @@ public class Notification
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed creating the Notification for {this}", ex);
+            Log.Error(ex, $"Failed creating the Notification for {this}");
             return false;
         }
 

--- a/src/GitHubExtension/DataModel/DataStore.cs
+++ b/src/GitHubExtension/DataModel/DataStore.cs
@@ -66,7 +66,7 @@ public class DataStore : IDisposable
                     // if we had a problem opening the DB and fetching the pragma, then
                     // we surely cannot reuse it.
                     deleteExistingDatabase = true;
-                    Log.Error($"Unable to open existing database to verify schema. Deleting database.", e);
+                    Log.Error(e, $"Unable to open existing database to verify schema. Deleting database.");
                 }
             }
 
@@ -92,16 +92,16 @@ public class DataStore : IDisposable
                 {
                     if ((uint)e.HResult == 0x80070020)
                     {
-                        Log.Fatal($"Sharing Violation Error; datastore exists and cannot be deleted ({DataStoreFilePath})", e);
+                        Log.Fatal(e, $"Sharing Violation Error; datastore exists and cannot be deleted ({DataStoreFilePath})");
                     }
                     else
                     {
-                        Log.Fatal($"I/O Error ({DataStoreFilePath})", e);
+                        Log.Fatal(e, $"I/O Error ({DataStoreFilePath})");
                     }
                 }
                 catch (UnauthorizedAccessException e)
                 {
-                    Log.Fatal($"Access Denied ({e})", e);
+                    Log.Fatal(e, $"Access Denied ({e})");
                 }
             }
         }
@@ -125,7 +125,7 @@ public class DataStore : IDisposable
             }
             catch (Exception e)
             {
-                Log.Fatal($"Failed creating directory: ({directory})", e);
+                Log.Fatal(e, $"Failed creating directory: ({directory})");
             }
         }
 
@@ -163,7 +163,7 @@ public class DataStore : IDisposable
         }
         catch (SqliteException e)
         {
-            Log.Fatal($"Failed to open connection: {Connection.ConnectionString}", e);
+            Log.Fatal(e, $"Failed to open connection: {Connection.ConnectionString}");
         }
 
         Log.Debug($"Opened DataStore at {DataStoreFilePath}");
@@ -259,7 +259,7 @@ public class DataStore : IDisposable
         }
         catch (SqliteException e)
         {
-            Log.Error($"Failure executing SQL Command: {command.CommandText}", e);
+            Log.Error(e, $"Failure executing SQL Command: {command.CommandText}");
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/CredentialVault.cs
+++ b/src/GitHubExtension/DeveloperId/CredentialVault.cs
@@ -130,7 +130,7 @@ public class CredentialVault : ICredentialVault
         }
         catch (Exception ex)
         {
-            Log.Error($"Retrieving credentials from Credential Manager has failed unexpectedly: {loginId} : ", ex);
+            Log.Error(ex, $"Retrieving credentials from Credential Manager has failed unexpectedly: {loginId} : ");
             throw;
         }
         finally
@@ -217,7 +217,7 @@ public class CredentialVault : ICredentialVault
             }
             catch (Exception ex)
             {
-                Log.Error($"Deleting credentials from Credential Manager has failed unexpectedly: {credential} : ", ex);
+                Log.Error(ex, $"Deleting credentials from Credential Manager has failed unexpectedly: {credential} : ");
             }
         }
     }

--- a/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/src/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -75,7 +75,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
         }
         catch (Exception ex)
         {
-            Log.Error($"Error while restoring DeveloperIds: {ex.Message}. Proceeding without restoring.", ex);
+            Log.Error(ex, $"Error while restoring DeveloperIds: {ex.Message}. Proceeding without restoring.");
         }
     }
 
@@ -131,7 +131,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
         }
         catch (Exception ex)
         {
-            Log.Error($"Error while logging in with PAT to {hostAddress.AbsoluteUri} : ", ex);
+            Log.Error(ex, $"Error while logging in with PAT to {hostAddress.AbsoluteUri} : ");
             throw;
         }
     }
@@ -151,7 +151,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
             catch (Exception ex)
             {
                 OAuthRequests.Remove(oauthRequest);
-                Log.Error($"Unable to complete OAuth request: ", ex);
+                Log.Error(ex, $"Unable to complete OAuth request: ");
             }
         }
 
@@ -180,7 +180,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
         }
         catch (Exception ex)
         {
-            Log.Error($"LoggedOut event signaling failed: ", ex);
+            Log.Error(ex, $"LoggedOut event signaling failed: ");
         }
 
         return new ProviderOperationResult(ProviderOperationStatus.Success, null, "The developer account has been logged out successfully", "LogoutDeveloperId succeeded");
@@ -264,7 +264,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Updated event signaling failed: ", ex);
+                    Log.Error(ex, $"Updated event signaling failed: ");
                 }
             }
             catch (InvalidOperationException)
@@ -288,7 +288,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
             }
             catch (Exception ex)
             {
-                Log.Error($"LoggedIn event signaling failed: ", ex);
+                Log.Error(ex, $"LoggedIn event signaling failed: ");
             }
         }
     }
@@ -350,7 +350,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
             }
             catch (Exception ex)
             {
-                Log.Error($"Error while restoring DeveloperId {loginIdOrUrl} : ", ex);
+                Log.Error(ex, $"Error while restoring DeveloperId {loginIdOrUrl} : ");
 
                 // If we are unable to restore a DeveloperId, remove it from CredentialManager to avoid
                 // the same error next time, and to force the user to login again
@@ -373,7 +373,7 @@ public class DeveloperIdProvider : IDeveloperIdProviderInternal
         }
         catch (Exception ex)
         {
-            Log.Error($"Error while replacing {developerId.LoginId} with {developerId.Url} in CredentialManager: ", ex);
+            Log.Error(ex, $"Error while replacing {developerId.LoginId} with {developerId.Url} in CredentialManager: ");
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUIController.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUIController.cs
@@ -98,7 +98,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
                         catch (Exception ex)
                         {
-                            Log.Error($"Error: ", ex);
+                            Log.Error(ex, $"Error: ");
                             new LoginFailedPage().UpdateExtensionAdaptiveCard(_loginUI);
                             operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, ex, "Error occurred in login page", ex.Message);
                         }
@@ -149,13 +149,13 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
                         catch (UriFormatException ufe)
                         {
-                            Log.Error($"Error: ", ufe);
+                            Log.Error(ufe, $"Error: ");
                             operationResult = new EnterpriseServerPage(hostAddress: enterprisePageInputPayload.EnterpriseServer, errorText: $"{Resources.GetResource("LoginUI_EnterprisePage_UriErrorText")}").UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
                         catch (Exception ex)
                         {
-                            Log.Error($"Error: ", ex);
+                            Log.Error(ex, $"Error: ");
                             operationResult = new EnterpriseServerPage(hostAddress: enterprisePageInputPayload.EnterpriseServer, errorText: $"{Resources.GetResource("LoginUI_EnterprisePage_GenericErrorText")} : {ex}").UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }
@@ -166,7 +166,7 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         }
                         catch (Exception ex)
                         {
-                            Log.Error($"Error: ", ex);
+                            Log.Error(ex, $"Error: ");
                             operationResult = new LoginFailedPage().UpdateExtensionAdaptiveCard(_loginUI);
                         }
 
@@ -220,13 +220,13 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                             }
                             catch (UriFormatException ufe)
                             {
-                                Log.Error($"Error: ", ufe);
+                                Log.Error(ufe, $"Error: ");
                                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, $"Error: {ufe}", $"Error: {ufe}");
                                 break;
                             }
                             catch (Exception ex)
                             {
-                                Log.Error($"Error: ", ex);
+                                Log.Error(ex, $"Error: ");
                                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, null, $"Error: {ex}", $"Error: {ex}");
                                 break;
                             }
@@ -277,12 +277,12 @@ public class LoginUIController : IExtensionAdaptiveCardSession
                         {
                             if (ex.Message.Contains("Bad credentials") || ex.Message.Contains("Not Found"))
                             {
-                                Log.Error($"Unauthorized Error: ", ex);
+                                Log.Error(ex, $"Unauthorized Error: ");
                                 operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_BadCredentialsErrorText")} {_hostAddress.OriginalString}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                                 break;
                             }
 
-                            Log.Error($"Error: ", ex);
+                            Log.Error(ex, $"Error: ");
                             operationResult = new EnterpriseServerPATPage(hostAddress: _hostAddress, errorText: $"{Resources.GetResource("LoginUI_EnterprisePATPage_GenericErrorPrefix")} {ex}", inputPAT: new NetworkCredential(null, enterprisePATPageInputPayload?.PAT).SecurePassword).UpdateExtensionAdaptiveCard(_loginUI);
                             break;
                         }

--- a/src/GitHubExtension/Helpers/Resources.cs
+++ b/src/GitHubExtension/Helpers/Resources.cs
@@ -23,7 +23,7 @@ public static class Resources
         }
         catch (Exception ex)
         {
-            log?.Error($"Failed loading resource: {identifier}", ex);
+            log?.Error(ex, $"Failed loading resource: {identifier}");
 
             // If we fail, load the original identifier so it is obvious which resource is missing.
             return identifier;

--- a/src/GitHubExtension/Notifications/NotificationHandler.cs
+++ b/src/GitHubExtension/Notifications/NotificationHandler.cs
@@ -47,7 +47,7 @@ public class NotificationHandler
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed launching Uri for {args.Arguments["htmlurl"]}", ex);
+                Log.Error(ex, $"Failed launching Uri for {args.Arguments["htmlurl"]}");
             }
 
             return;

--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -129,7 +129,7 @@ public class RepositoryProvider : IRepositoryProvider
             catch (Exception ex)
             {
                 // Any failures should be thrown so the core app can catch the failures.
-                Log.Error("Failed getting list of repositories.", ex);
+                Log.Error(ex, "Failed getting list of repositories.");
                 return new RepositoriesResult(ex, $"Something went wrong.  HResult: {ex.HResult}");
             }
 
@@ -189,13 +189,13 @@ public class RepositoryProvider : IRepositoryProvider
 
                 if (innerException is Octokit.RateLimitExceededException)
                 {
-                    Log.Error("Rate limit exceeded.", e);
+                    Log.Error(innerException, "Rate limit exceeded.");
                     return new RepositoryResult(innerException, $"Rate limit exceeded. HResult: {innerException.HResult}");
                 }
             }
             catch (Exception e)
             {
-                Log.Error("Unspecified error.", e);
+                Log.Error(e, "Unspecified error.");
                 return new RepositoryResult(e, $"Unspecified error when cloning a repo. HResult: {e.HResult}");
             }
 
@@ -239,7 +239,7 @@ public class RepositoryProvider : IRepositoryProvider
                 }
                 catch (Exception e)
                 {
-                    Log.Error("Could not get credentials.", e);
+                    Log.Error(e, "Could not get credentials.");
                     return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Could not get credentials.", e.Message);
                 }
             }
@@ -251,27 +251,27 @@ public class RepositoryProvider : IRepositoryProvider
             }
             catch (LibGit2Sharp.RecurseSubmodulesException recurseException)
             {
-                Log.Error("Could not clone all submodules.", recurseException);
+                Log.Error(recurseException, "Could not clone all submodules.");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, recurseException, "Could not clone all submodules.", recurseException.Message);
             }
             catch (LibGit2Sharp.UserCancelledException userCancelledException)
             {
-                Log.Error("The user stopped the clone operation.", userCancelledException);
+                Log.Error(userCancelledException, "The user stopped the clone operation.");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, userCancelledException, "User cancelled the clone operation.", userCancelledException.Message);
             }
             catch (LibGit2Sharp.NameConflictException nameConflictException)
             {
-                Log.Error("Name conflict", nameConflictException);
+                Log.Error(nameConflictException, "Name conflict");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, nameConflictException, "The destination location is non-empty.", nameConflictException.Message);
             }
             catch (LibGit2Sharp.LibGit2SharpException libGitTwoException)
             {
-                Log.Error($"Either no logged in account has access to this repository, or the repository can't be found.", libGitTwoException);
+                Log.Error(libGitTwoException, $"Either no logged in account has access to this repository, or the repository can't be found.");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LibGit2 library threw an exception.", "LibGit2 library threw an exception.");
             }
             catch (Exception e)
             {
-                Log.Error("Could not clone the repository.", e);
+                Log.Error(e, "Could not clone the repository.");
                 return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repository.", "Something happened when cloning the repository.");
             }
 

--- a/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
@@ -79,7 +79,7 @@ internal class GitHubIssuesWidget : GitHubRepositoryWidget
         }
         catch (Exception ex)
         {
-            Log.Error("Failed requesting data update.", ex);
+            Log.Error(ex, "Failed requesting data update.");
         }
     }
 
@@ -162,7 +162,7 @@ internal class GitHubIssuesWidget : GitHubRepositoryWidget
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -69,7 +69,7 @@ internal class GitHubPullsWidget : GitHubRepositoryWidget
         }
         catch (Exception ex)
         {
-            Log.Error("Failed requesting data update.", ex);
+            Log.Error(ex, "Failed requesting data update.");
         }
     }
 
@@ -135,7 +135,7 @@ internal class GitHubPullsWidget : GitHubRepositoryWidget
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/src/GitHubExtension/Widgets/GitHubReleasesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReleasesWidget.cs
@@ -55,7 +55,7 @@ internal class GitHubReleasesWidget : GitHubRepositoryWidget
         }
         catch (Exception ex)
         {
-            Log.Error("Failed requesting data update.", ex);
+            Log.Error(ex, "Failed requesting data update.");
         }
     }
 
@@ -132,7 +132,7 @@ internal class GitHubReleasesWidget : GitHubRepositoryWidget
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -168,7 +168,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
             catch (Exception ex)
             {
                 // Adding for abundance of caution because we have seen crashes in this space.
-                Log.Error($"Unexpected failure during migration.", ex);
+                Log.Error(ex, $"Unexpected failure during migration.");
             }
         }
 
@@ -183,7 +183,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
             // If we fail to parse configuration data, do nothing, report the failure, and don't
             // crash the entire extension.
             RepositoryUrl = string.Empty;
-            Log.Error($"Unexpected error while resetting state: {e.Message}", e);
+            Log.Error(e, $"Unexpected error while resetting state: {e.Message}");
         }
     }
 
@@ -267,7 +267,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed getting configuration information for input url: {dataUrl}", ex);
+                Log.Error(ex, $"Failed getting configuration information for input url: {dataUrl}");
                 configurationData.Add("hasConfiguration", false);
 
                 var repositoryData = new JsonObject

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -108,7 +108,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             catch (Exception ex)
             {
                 // Adding for abundance of caution because we have seen crashes in this space.
-                Log.Error($"Unexpected failure during migration.", ex);
+                Log.Error(ex, $"Unexpected failure during migration.");
             }
         }
 
@@ -125,7 +125,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             // crash the entire extension.
             DeveloperLoginId = string.Empty;
             ShowCategory = SearchCategory.Unknown;
-            Log.Error($"Unexpected error while resetting state: {e.Message}", e);
+            Log.Error(e, $"Unexpected error while resetting state: {e.Message}");
         }
     }
 
@@ -238,7 +238,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
         }
         catch (Exception ex)
         {
-            Log.Error("Failed requesting data update.", ex);
+            Log.Error(ex, "Failed requesting data update.");
         }
     }
 
@@ -310,7 +310,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -276,7 +276,7 @@ public abstract class GitHubWidget : WidgetImpl
         }
         catch (Exception e)
         {
-            Log.Error("Error getting template.", e);
+            Log.Error(e, "Error getting template.");
             return string.Empty;
         }
     }
@@ -376,7 +376,7 @@ public abstract class GitHubWidget : WidgetImpl
         }
         catch (Exception ex)
         {
-            Log.Error("Failed Requesting Update", ex);
+            Log.Error(ex, "Failed Requesting Update");
         }
 
         lastUpdateRequest = DateTime.Now;

--- a/src/GitHubExtension/Widgets/WidgetProvider.cs
+++ b/src/GitHubExtension/Widgets/WidgetProvider.cs
@@ -62,7 +62,7 @@ public sealed class WidgetProvider : IWidgetProvider, IWidgetProvider2
         }
         catch (Exception e)
         {
-            _log.Error("Failed retrieving list of running widgets.", e);
+            _log.Error(e, "Failed retrieving list of running widgets.");
             return;
         }
 

--- a/src/GitHubExtensionServer/Program.cs
+++ b/src/GitHubExtensionServer/Program.cs
@@ -168,7 +168,7 @@ public sealed class Program
         }
         catch (Exception ex)
         {
-            Log.Error("Failed getting package information.", ex);
+            Log.Error(ex, "Failed getting package information.");
         }
     }
 }


### PR DESCRIPTION
## Summary of the pull request
This fixes the ordering of exception logging such that exceptions will be properly logged.

## References and relevant issues
Closes #378 

## Detailed description of the pull request / Additional comments
Serilog has multiple valid logging signatures, but the only one that logs exceptions is if the exception is the first argument. Exceptions can be placed validly as 2nd, 3rd, etc. arguments after a string but those are assumed to be part of the message template and otherwise ignored. This resulted in valid log messages but exceptions that were intended to be logged were not being logged.

* Fixed all Fatal, Error, Warning, Debug, and Information logging that included an exception at the end of the message and moved it to the front of the message so it would be logged instead of swallowed.

## Validation steps performed
* Build validation

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
