### PR TITLE
Returning exception message for more general exceptions.

### DIFF
--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -267,12 +267,12 @@ public class RepositoryProvider : IRepositoryProvider
             catch (LibGit2Sharp.LibGit2SharpException libGitTwoException)
             {
                 Log.Error(libGitTwoException, $"Either no logged in account has access to this repository, or the repository can't be found.");
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LibGit2Sharp threw an exception.  Please check the logs for more details.", libGitTwoException.Message);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, libGitTwoException.Message, libGitTwoException.Message);
             }
             catch (Exception e)
             {
                 Log.Error(e, "Could not clone the repository.");
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repository.  Please check the logs for more details.", e.Message);
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, e.Message, e.Message);
             }
 
             return new ProviderOperationResult(ProviderOperationStatus.Success, new ArgumentException("Nothing wrong"), "Nothing wrong", "Nothing wrong");

--- a/src/GitHubExtension/Providers/RepositoryProvider.cs
+++ b/src/GitHubExtension/Providers/RepositoryProvider.cs
@@ -267,12 +267,12 @@ public class RepositoryProvider : IRepositoryProvider
             catch (LibGit2Sharp.LibGit2SharpException libGitTwoException)
             {
                 Log.Error(libGitTwoException, $"Either no logged in account has access to this repository, or the repository can't be found.");
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LibGit2 library threw an exception.", "LibGit2 library threw an exception.");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, libGitTwoException, "LibGit2Sharp threw an exception.  Please check the logs for more details.", libGitTwoException.Message);
             }
             catch (Exception e)
             {
                 Log.Error(e, "Could not clone the repository.");
-                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repository.", "Something happened when cloning the repository.");
+                return new ProviderOperationResult(ProviderOperationStatus.Failure, e, "Something happened when cloning the repository.  Please check the logs for more details.", e.Message);
             }
 
             return new ProviderOperationResult(ProviderOperationStatus.Success, new ArgumentException("Nothing wrong"), "Nothing wrong", "Nothing wrong");


### PR DESCRIPTION
## Summary of the pull request
General exceptions did not show up in either the loading screen or the logs.

Any libgit2sharp and Exception exceptions will show their message in the loading screen.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
