### PR TITLE
Fixing bug where title was not saved when Save button is clicked

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubWidget.cs
@@ -130,6 +130,8 @@ public abstract class GitHubWidget : WidgetImpl
                 // It might take some time to get the new data, so
                 // set data state to "unknown" so that loading page is shown.
                 DataState = WidgetDataState.Unknown;
+
+                ConfigurationData = actionInvokedArgs.Data;
                 UpdateWidget();
 
                 SavedConfigurationData = string.Empty;


### PR DESCRIPTION
## Summary of the pull request
This PR fixes a bug where if the user changes the title of the widget and clics "Save" button, the configuration is not saved.
Now, whenever the "Save" action is invoked, we save the data as the `ConfigurationData` of the widget.
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
