### PR TITLE
Saving the entire URL on the Repository Widgets

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -55,6 +55,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         {
             configurationData["url"] = RepositoryUrl;
             ConfigurationData = configurationData.ToJsonString();
+            UpdateWidget();
         }
     }
 

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -46,6 +46,18 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         return Uri.UnescapeDataString(GetIssueQuery()).Replace('+', ' ');
     }
 
+    // If the user changed the URL after clicking submit and clicked
+    // saved just after, we change it back to what was before to not corrupt our saved data.
+    private void CorrectUrl()
+    {
+        var configurationData = JsonNode.Parse(ConfigurationData);
+        if (configurationData != null)
+        {
+            configurationData["url"] = RepositoryUrl;
+            ConfigurationData = configurationData.ToJsonString();
+        }
+    }
+
     public override void OnActionInvoked(WidgetActionInvokedArgs actionInvokedArgs)
     {
         var verb = GetWidgetActionForVerb(actionInvokedArgs.Verb);
@@ -60,6 +72,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
             case WidgetAction.Save:
                 UpdateTitle(JsonNode.Parse(actionInvokedArgs.Data));
                 base.OnActionInvoked(actionInvokedArgs);
+                CorrectUrl();
                 break;
 
             default:

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -256,7 +256,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
                     { "owner", repository.Owner.Login },
                     { "milestone", string.Empty },
                     { "project", repository.Description },
-                    { "url", repository.HtmlUrl },
+                    { "url", RepositoryUrl },
                     { "query", GetUnescapedIssueQuery() },
                 };
 


### PR DESCRIPTION
## Summary of the pull request
When the widget was being saved, we changed the data to include only the main URL, without the query. This created a bug when if the user customized the widget but cancelled the process, the widget would lose track of its query because it was not being saved on the `ConfigurationData`. With this PR, we never change the actual URL that the user used as input, keeping it consistent.

This PR also fixes the issue where we could save widgets with invalid URLs. This would happen if the user submit a URL, change it for some reason, and then save the widget. As the save action also gets data (important to get the last title input for example), we need to correct it to the URL we are sure is correct.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #396
- [ ] Tests added/passed
- [ ] Documentation updated
