### PR TITLE
Fix duplicate classIDs for different builds

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -20,7 +20,7 @@ parameters:
     - release
 
 variables:
-  MSIXVersion: '0.1600'
+  MSIXVersion: '0.1700'
   solution: '**/GitHubExtension.sln'
   appxPackageDir: 'AppxPackages'
   testOutputArtifactDir: 'TestResults'

--- a/build/scripts/CreateBuildInfo.ps1
+++ b/build/scripts/CreateBuildInfo.ps1
@@ -5,7 +5,7 @@ Param(
 )
 
 $Major = "0"
-$Minor = "16"
+$Minor = "17"
 $Patch = "99" # default to 99 for local builds
 
 $versionSplit = $Version.Split(".");

--- a/src/GitHubExtension/GitHubExtension.cs
+++ b/src/GitHubExtension/GitHubExtension.cs
@@ -10,7 +10,13 @@ using Serilog;
 namespace GitHubExtension;
 
 [ComVisible(true)]
+#if CANARY_BUILD
+[Guid("7AB70F8F-3644-495C-B473-A6750AE1D547")]
+#elif STABLE_BUILD
 [Guid("6B5F1179-B2AE-4D5E-94FC-E5E119D1B8F0")]
+#else
+[Guid("190B5CB2-BBAC-424E-92F8-98C7C41C1039")]
+#endif
 [ComDefaultInterface(typeof(IExtension))]
 public sealed class GitHubExtension : IExtension
 {

--- a/src/GitHubExtension/Widgets/WidgetProvider.cs
+++ b/src/GitHubExtension/Widgets/WidgetProvider.cs
@@ -9,7 +9,13 @@ namespace GitHubExtension.Widgets;
 
 [ComVisible(true)]
 [ClassInterface(ClassInterfaceType.None)]
+#if CANARY_BUILD
+[Guid("E8778523-0D5F-478F-8AC3-1467928BDEF7")]
+#elif STABLE_BUILD
 [Guid("F23870B0-B391-4466-84E2-42A991078613")]
+#else
+[Guid("3AF3462E-0CCE-4200-887B-FB41872A4EFB")]
+#endif
 public sealed class WidgetProvider : IWidgetProvider, IWidgetProvider2
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WidgetProvider));

--- a/src/GitHubExtensionServer/GitHubExtensionServer.csproj
+++ b/src/GitHubExtensionServer/GitHubExtensionServer.csproj
@@ -44,6 +44,24 @@
     <Folder Include="Assets\" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(BuildRing)' == 'Dev'">
+    <AppxManifest Include="Package-Dev.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildRing)' == 'Canary'">
+    <AppxManifest Include="Package-Can.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildRing)' == 'Stable'">
+    <AppxManifest Include="Package.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />

--- a/src/GitHubExtensionServer/Package-Can.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Can.appxmanifest
@@ -22,14 +22,14 @@
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeGitHubExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="GitHub Extension Widget">
-              <com:Class Id="F23870B0-B391-4466-84E2-42A991078613" DisplayName="GitHub Extension Widget" />
+              <com:Class Id="E8778523-0D5F-478F-8AC3-1467928BDEF7" DisplayName="GitHub Extension Widget" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeGitHubExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="GitHub Extension">
-              <com:Class Id="6B5F1179-B2AE-4D5E-94FC-E5E119D1B8F0" DisplayName="GitHub Extension" />
+              <com:Class Id="7AB70F8F-3644-495C-B473-A6750AE1D547" DisplayName="GitHub Extension" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>

--- a/src/GitHubExtensionServer/Package-Can.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Can.appxmanifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
-  <Identity Name="Microsoft.Windows.DevHomeGitHubExtension" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
+  <Identity Name="Microsoft.Windows.DevHomeGitHubExtension.Can" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home GitHub Extension</DisplayName>
+    <DisplayName>Dev Home GitHub Extension (Can)</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -14,7 +14,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="DevHomeGitHubExtension.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
+      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameCanary" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
         <uap:DefaultTile Wide310x150Logo="Assets\WideTile.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
@@ -34,11 +34,11 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameCanary" Description="ms-resource:AppDescription">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="6B5F1179-B2AE-4D5E-94FC-E5E119D1B8F0" />
+                  <CreateInstance ClassId="7AB70F8F-3644-495C-B473-A6750AE1D547" />
                 </Activation>
                 <SupportedInterfaces>
                   <DeveloperId />
@@ -65,7 +65,7 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameStable" Id="01" PublicFolder="Public">
+          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameCanary" Id="01" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>
                 <ProviderIcons>
@@ -73,7 +73,7 @@
                 </ProviderIcons>
                 <Activation>
                   <!-- Apps exports COM interface which implements IWidgetProvider -->
-                  <CreateInstance ClassId="F23870B0-B391-4466-84E2-42A991078613" />
+                  <CreateInstance ClassId="E8778523-0D5F-478F-8AC3-1467928BDEF7" />
                 </Activation>
                 <Definitions>
                   <Definition Id="GitHub_Issues" DisplayName="Issues" Description="List of issues in a GitHub repository." IsCustomizable="true">

--- a/src/GitHubExtensionServer/Package-Dev.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Dev.appxmanifest
@@ -22,14 +22,14 @@
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeGitHubExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="GitHub Extension Widget">
-              <com:Class Id="F23870B0-B391-4466-84E2-42A991078613" DisplayName="GitHub Extension Widget" />
+              <com:Class Id="3AF3462E-0CCE-4200-887B-FB41872A4EFB" DisplayName="GitHub Extension Widget" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="DevHomeGitHubExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="GitHub Extension">
-              <com:Class Id="6B5F1179-B2AE-4D5E-94FC-E5E119D1B8F0" DisplayName="GitHub Extension" />
+              <com:Class Id="190B5CB2-BBAC-424E-92F8-98C7C41C1039" DisplayName="GitHub Extension" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>

--- a/src/GitHubExtensionServer/Package-Dev.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Dev.appxmanifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap uap3 rescap genTemplate">
-  <Identity Name="Microsoft.Windows.DevHomeGitHubExtension" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
+  <Identity Name="Microsoft.Windows.DevHomeGitHubExtension.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home GitHub Extension</DisplayName>
+    <DisplayName>Dev Home GitHub Extension (Dev)</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -14,7 +14,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="DevHomeGitHubExtension.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
+      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription" AppListEntry="none" BackgroundColor="transparent" Square150x150Logo="Assets\MedTile.png" Square44x44Logo="Assets\AppList.png">
         <uap:DefaultTile Wide310x150Logo="Assets\WideTile.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
@@ -34,11 +34,11 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="6B5F1179-B2AE-4D5E-94FC-E5E119D1B8F0" />
+                  <CreateInstance ClassId="190B5CB2-BBAC-424E-92F8-98C7C41C1039" />
                 </Activation>
                 <SupportedInterfaces>
                   <DeveloperId />
@@ -65,7 +65,7 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameStable" Id="01" PublicFolder="Public">
+          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="01" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>
                 <ProviderIcons>
@@ -73,7 +73,7 @@
                 </ProviderIcons>
                 <Activation>
                   <!-- Apps exports COM interface which implements IWidgetProvider -->
-                  <CreateInstance ClassId="F23870B0-B391-4466-84E2-42A991078613" />
+                  <CreateInstance ClassId="3AF3462E-0CCE-4200-887B-FB41872A4EFB" />
                 </Activation>
                 <Definitions>
                   <Definition Id="GitHub_Issues" DisplayName="Issues" Description="List of issues in a GitHub repository." IsCustomizable="true">


### PR DESCRIPTION
## Summary of the pull request
Stable/Canary/Dev builds all use the same ClassIds in package.appxmanifest.  This causes issues when multiple versions are installed at the same time, notably not being able to determine which version will actually get activated.  This change clones package.appxmanifest into three different versions and changes the ClassIds for Canary/Dev versions (Stable remains the same).

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
