### PR TITLE
Fix widget manifest localization

### DIFF
--- a/src/GitHubExtensionServer/Package-Can.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Can.appxmanifest
@@ -76,7 +76,7 @@
                   <CreateInstance ClassId="E8778523-0D5F-478F-8AC3-1467928BDEF7" />
                 </Activation>
                 <Definitions>
-                  <Definition Id="GitHub_Issues" DisplayName="Issues" Description="List of issues in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_Issues" DisplayName="ms-resource:Widget_DisplayName_Issues" Description="ms-resource:Widget_Description_Issues" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -90,14 +90,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="Issues widget preview image" />
+                        <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\IssuesScreenshotDark.png" DisplayAltText="Issues widget preview image" />
+                          <Screenshot Path="Widgets\Assets\IssuesScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -105,12 +105,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="Issues widget preview image" />
+                          <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_PullRequests" DisplayName="Pull requests" Description="List of open pull requests in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_PullRequests" DisplayName="ms-resource:Widget_DisplayName_PullRequests" Description="ms-resource:Widget_Description_PullRequests" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -124,14 +124,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="Pull Requests widget preview image" />
+                        <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotDark.png" DisplayAltText="Pull Requests widget preview image" />
+                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -139,12 +139,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="Pull Requests widget preview image" />
+                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_MentionedIns" DisplayName="Mentioned me" Description="List of issues and pull requests the user is mentioned in in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_MentionedIns" DisplayName="ms-resource:Widget_DisplayName_MentionedIn" Description="ms-resource:Widget_Description_MentionedIn" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -158,14 +158,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="Mentioned In widget preview image" />
+                        <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotDark.png" DisplayAltText="Mentioned In widget preview image" />
+                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -173,12 +173,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="Mentioned In widget preview image" />
+                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Assigneds" DisplayName="Assigned to me" Description="List of pull requests and issues assigned to the user in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_Assigneds" DisplayName="ms-resource:Widget_DisplayName_AssignedToMe" Description="ms-resource:Widget_Description_AssignedToMe" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -192,14 +192,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="Assigned To Me widget preview image" />
+                        <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotDark.png" DisplayAltText="Assigned To Me widget preview image" />
+                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -207,12 +207,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="Assigned To Me widget preview image" />
+                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Reviews" DisplayName="Review requested" Description="List of pull requests where the user is requested for a review." IsCustomizable="false">
+                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="false">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -226,14 +226,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="Review Requested widget preview image" />
+                        <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotDark.png" DisplayAltText="Review Requested widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -241,7 +241,7 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="Review Requested widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
@@ -260,14 +260,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="Releases widget preview image" />
+                        <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotDark.png" DisplayAltText="Releases widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -275,7 +275,7 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="Releases widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>

--- a/src/GitHubExtensionServer/Package-Dev.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Dev.appxmanifest
@@ -76,7 +76,7 @@
                   <CreateInstance ClassId="3AF3462E-0CCE-4200-887B-FB41872A4EFB" />
                 </Activation>
                 <Definitions>
-                  <Definition Id="GitHub_Issues" DisplayName="Issues" Description="List of issues in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_Issues" DisplayName="ms-resource:Widget_DisplayName_Issues" Description="ms-resource:Widget_Description_Issues" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -90,14 +90,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="Issues widget preview image" />
+                        <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\IssuesScreenshotDark.png" DisplayAltText="Issues widget preview image" />
+                          <Screenshot Path="Widgets\Assets\IssuesScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -105,12 +105,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="Issues widget preview image" />
+                          <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_PullRequests" DisplayName="Pull requests" Description="List of open pull requests in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_PullRequests" DisplayName="ms-resource:Widget_DisplayName_PullRequests" Description="ms-resource:Widget_Description_PullRequests" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -124,14 +124,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="Pull Requests widget preview image" />
+                        <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotDark.png" DisplayAltText="Pull Requests widget preview image" />
+                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -139,12 +139,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="Pull Requests widget preview image" />
+                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_MentionedIns" DisplayName="Mentioned me" Description="List of issues and pull requests the user is mentioned in in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_MentionedIns" DisplayName="ms-resource:Widget_DisplayName_MentionedIn" Description="ms-resource:Widget_Description_MentionedIn" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -158,14 +158,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="Mentioned In widget preview image" />
+                        <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotDark.png" DisplayAltText="Mentioned In widget preview image" />
+                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -173,12 +173,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="Mentioned In widget preview image" />
+                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Assigneds" DisplayName="Assigned to me" Description="List of pull requests and issues assigned to the user in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_Assigneds" DisplayName="ms-resource:Widget_DisplayName_AssignedToMe" Description="ms-resource:Widget_Description_AssignedToMe" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -192,14 +192,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="Assigned To Me widget preview image" />
+                        <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotDark.png" DisplayAltText="Assigned To Me widget preview image" />
+                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -207,12 +207,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="Assigned To Me widget preview image" />
+                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Reviews" DisplayName="Review requested" Description="List of pull requests where the user is requested for a review." IsCustomizable="false">
+                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="false">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -226,14 +226,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="Review Requested widget preview image" />
+                        <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotDark.png" DisplayAltText="Review Requested widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -241,7 +241,7 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="Review Requested widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
@@ -260,14 +260,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="Releases widget preview image" />
+                        <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotDark.png" DisplayAltText="Releases widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -275,7 +275,7 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="Releases widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>

--- a/src/GitHubExtensionServer/Package.appxmanifest
+++ b/src/GitHubExtensionServer/Package.appxmanifest
@@ -76,7 +76,7 @@
                   <CreateInstance ClassId="F23870B0-B391-4466-84E2-42A991078613" />
                 </Activation>
                 <Definitions>
-                  <Definition Id="GitHub_Issues" DisplayName="Issues" Description="List of issues in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_Issues" DisplayName="ms-resource:Widget_DisplayName_Issues" Description="ms-resource:Widget_Description_Issues" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -90,14 +90,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="Issues widget preview image" />
+                        <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\IssuesScreenshotDark.png" DisplayAltText="Issues widget preview image" />
+                          <Screenshot Path="Widgets\Assets\IssuesScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -105,12 +105,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="Issues widget preview image" />
+                          <Screenshot Path="Widgets\Assets\IssuesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Issues" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_PullRequests" DisplayName="Pull requests" Description="List of open pull requests in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_PullRequests" DisplayName="ms-resource:Widget_DisplayName_PullRequests" Description="ms-resource:Widget_Description_PullRequests" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -124,14 +124,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="Pull Requests widget preview image" />
+                        <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotDark.png" DisplayAltText="Pull Requests widget preview image" />
+                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -139,12 +139,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="Pull Requests widget preview image" />
+                          <Screenshot Path="Widgets\Assets\PullRequestsScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_PullRequests" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_MentionedIns" DisplayName="Mentioned me" Description="List of issues and pull requests the user is mentioned in in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_MentionedIns" DisplayName="ms-resource:Widget_DisplayName_MentionedIn" Description="ms-resource:Widget_Description_MentionedIn" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -158,14 +158,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="Mentioned In widget preview image" />
+                        <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotDark.png" DisplayAltText="Mentioned In widget preview image" />
+                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -173,12 +173,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="Mentioned In widget preview image" />
+                          <Screenshot Path="Widgets\Assets\MentionedInScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_MentionedIn" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Assigneds" DisplayName="Assigned to me" Description="List of pull requests and issues assigned to the user in a GitHub repository." IsCustomizable="true">
+                  <Definition Id="GitHub_Assigneds" DisplayName="ms-resource:Widget_DisplayName_AssignedToMe" Description="ms-resource:Widget_Description_AssignedToMe" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -192,14 +192,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="Assigned To Me widget preview image" />
+                        <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotDark.png" DisplayAltText="Assigned To Me widget preview image" />
+                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -207,12 +207,12 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="Assigned To Me widget preview image" />
+                          <Screenshot Path="Widgets\Assets\AssignedToMeScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_AssignedToMe" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Reviews" DisplayName="Review requested" Description="List of pull requests where the user is requested for a review." IsCustomizable="false">
+                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="false">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />
@@ -226,14 +226,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="Review Requested widget preview image" />
+                        <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotDark.png" DisplayAltText="Review Requested widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -241,7 +241,7 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="Review Requested widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReviewRequestedScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Reviews" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>
@@ -260,14 +260,14 @@
                         <Icon Path="Widgets\Assets\GitHubLogo_Light.jpg" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="Releases widget preview image" />
+                        <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\GitHubLogo_Dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotDark.png" DisplayAltText="Releases widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotDark.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode>
@@ -275,7 +275,7 @@
                           <Icon Path="Widgets\Assets\GitHubLogo_Light.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="Releases widget preview image" />
+                          <Screenshot Path="Widgets\Assets\ReleasesScreenshotLight.png" DisplayAltText="ms-resource:Widget_ScreenshotAltDisplay_Releases" />
                         </Screenshots>
                       </LightMode>
                     </ThemeResources>

--- a/src/GitHubExtensionServer/Strings/en-us/Resources.resw
+++ b/src/GitHubExtensionServer/Strings/en-us/Resources.resw
@@ -153,4 +153,52 @@
     <value>Releases</value>
     <comment>Title for widget that displays the releases of a repository</comment>
   </data>
+  <data name="Widget_Description_AssignedToMe" xml:space="preserve">
+    <value>List of pull requests and issues assigned to the user in a GitHub repository.</value>
+  </data>
+  <data name="Widget_Description_Issues" xml:space="preserve">
+    <value>List of issues in a GitHub repository.</value>
+  </data>
+  <data name="Widget_Description_MentionedIn" xml:space="preserve">
+    <value>List of issues and pull requests the user is mentioned in in a GitHub repository.</value>
+  </data>
+  <data name="Widget_Description_PullRequests" xml:space="preserve">
+    <value>List of open pull requests in a GitHub repository.</value>
+  </data>
+  <data name="Widget_Description_Reviews" xml:space="preserve">
+    <value>List of pull requests where the user is requested for a review.</value>
+  </data>
+  <data name="Widget_DisplayName_AssignedToMe" xml:space="preserve">
+    <value>Assigned to me</value>
+  </data>
+  <data name="Widget_DisplayName_Issues" xml:space="preserve">
+    <value>Issues</value>
+  </data>
+  <data name="Widget_DisplayName_MentionedIn" xml:space="preserve">
+    <value>Mentioned me</value>
+  </data>
+  <data name="Widget_DisplayName_PullRequests" xml:space="preserve">
+    <value>Pull requests</value>
+  </data>
+  <data name="Widget_DisplayName_Reviews" xml:space="preserve">
+    <value>Review requested</value>
+  </data>
+  <data name="Widget_ScreenshotAltDisplay_AssignedToMe" xml:space="preserve">
+    <value>Assigned To Me widget preview image</value>
+  </data>
+  <data name="Widget_ScreenshotAltDisplay_Issues" xml:space="preserve">
+    <value>Issues widget preview image</value>
+  </data>
+  <data name="Widget_ScreenshotAltDisplay_MentionedIn" xml:space="preserve">
+    <value>Mentioned In widget preview image</value>
+  </data>
+  <data name="Widget_ScreenshotAltDisplay_PullRequests" xml:space="preserve">
+    <value>Pull Requests widget preview image</value>
+  </data>
+  <data name="Widget_ScreenshotAltDisplay_Releases" xml:space="preserve">
+    <value>Releases widget preview image</value>
+  </data>
+  <data name="Widget_ScreenshotAltDisplay_Reviews" xml:space="preserve">
+    <value>Review Requested widget preview image</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Widgets were not properly localized in the manifest. This fixes that.

## References and relevant issues
#249 

## Detailed description of the pull request / Additional comments
* Added strings for DisplayName, Description, and the alternate screenshot text.

## Validation steps performed
Built and verified widget display name looks is the localized text and not the resource identifiers in the Add Widget dialog, and in the widgets.
 
## PR checklist
- [x] Closes #249 
- [x] Tests added/passed
- [x] Documentation updated
