### PR TITLE
Simplifying Issues and Pull Requests Widgets customization

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using GitHubExtension.Client;
 using GitHubExtension.DataManager;
-using GitHubExtension.Helpers;
-using GitHubExtension.Providers;
 using GitHubExtension.Widgets.Enums;
-using Microsoft.Windows.DevHome.SDK;
 using Microsoft.Windows.Widgets.Providers;
 
 namespace GitHubExtension.Widgets;
@@ -258,7 +254,7 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
 
             WidgetManager.GetDefault().UpdateWidget(updateRequestOptions);
 
-            // Already shown error message while updatind above,
+            // Already shown error message while updating above,
             // can reset it to null here.
             _message = null;
             return isGoodToSave;

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -273,81 +273,13 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
     {
         var configurationData = new JsonObject
         {
-            { "submitIcon", IconLoader.GetIconAsBase64("arrow.png") },
             { "widgetTitle", WidgetTitle },
+            { "url", dataUrl },
+            { "savedRepositoryUrl", SavedConfigurationData },
+            { "errorMessage", _message },
         };
 
-        var knownRepositories = GetKnownRepositories();
-        var knownRepositoriesJson = new JsonArray();
-
-        foreach (var repoName in knownRepositories)
-        {
-            var repositoryJson = new JsonObject
-            {
-                { "name", repoName },
-            };
-            knownRepositoriesJson.Add(repositoryJson);
-        }
-
-        configurationData.Add("knownRepositories", knownRepositoriesJson);
-        configurationData.Add("url", dataUrl);
-        configurationData.Add("savedRepositoryUrl", SavedConfigurationData);
-        configurationData.Add("errorMessage", _message);
-
         return configurationData.ToJsonString();
-    }
-
-    public List<string> GetKnownRepositories()
-    {
-        var res = new List<string>();
-
-        try
-        {
-            var dataManager = GitHubDataManager.CreateInstance();
-            var repositories = dataManager?.GetRepositories();
-
-            if (repositories != null)
-            {
-                foreach (var repository in repositories)
-                {
-                    res.Add(repository.FullName);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Failed to get known repositories from data store.");
-        }
-
-        try
-        {
-            var devIds = DeveloperId.DeveloperIdProvider.GetInstance().GetLoggedInDeveloperIdsInternal();
-
-            IRepositoryProvider repositoryProvider = new RepositoryProvider();
-
-            foreach (var devId in devIds)
-            {
-                var userRepositoriesAsync = repositoryProvider.GetRepositoriesAsync(devId);
-
-                userRepositoriesAsync.AsTask().Wait();
-
-                var userRepositories = userRepositoriesAsync.AsTask().Result.Repositories;
-
-                foreach (var userRepository in userRepositories)
-                {
-                    var localPath = userRepository.RepoUri.LocalPath;
-                    res.Add(localPath.Substring(1, localPath.Length - 5)); // remove initial "/" and final ".git"
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Failed to get known repositories from GitHub API.");
-        }
-
-        // res.Sort();
-        // Removing repeated entries
-        return res.Distinct().ToList();
     }
 
     public override string GetData(WidgetPageState page)

--- a/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubIssuesConfigurationTemplate.json
@@ -7,16 +7,10 @@
       "type": "Input.Text",
       "id": "url",
       "label": "%Widget_Template_Label/Url%",
-      "inlineAction": {
-        "type": "Action.Execute",
-        "tooltip": "%Widget_Template_Tooltip/Submit%",
-        "verb": "CheckUrl",
-        "iconUrl": "data:image/png;base64,${submitIcon}"
-      },
       "spacing": "Medium",
       "style": "Url",
       "placeholder": "%Widget_Template_Input/UrlPlaceholder%",
-      "value": "${$root.configuration.url}"
+      "value": "${url}"
     },
     {
       "type": "Input.Text",
@@ -115,8 +109,7 @@
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/Save%",
                       "verb": "Save",
-                      "tooltip": "%Widget_Template_Tooltip/Save%",
-                      "isEnabled": "${$root.saveEnabled}"
+                      "tooltip": "%Widget_Template_Tooltip/Save%"
                     },
                     {
                       "type": "Action.Execute",

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -1,7 +1,7 @@
 {
   "type": "AdaptiveCard",
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "version": "1.6",
+  "version": "1.5",
   "body": [
     {
       "type": "Input.Text",
@@ -11,20 +11,6 @@
       "style": "Url",
       "placeholder": "%Widget_Template_Input/UrlPlaceholder%",
       "value": "${url}"
-    },
-    {
-      "type": "Input.ChoiceSet",
-      "id": "knownrepo",
-      "label": "Known repositories",
-      "placeholder": "Select a repository",
-      "value":  "test",
-      "choices": [
-        {
-          "$data": "${knownRepositories}",
-          "title": "${name}",
-          "value": "${name}"
-        }
-      ]
     },
     {
       "type": "Input.Text",

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -17,6 +17,7 @@
       "id": "knownrepo",
       "label": "Known repositories",
       "placeholder": "Select a repository",
+      "value":  "test",
       "choices": [
         {
           "$data": "${knownRepositories}",

--- a/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubPullsConfigurationTemplate.json
@@ -1,22 +1,29 @@
 {
   "type": "AdaptiveCard",
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "version": "1.5",
+  "version": "1.6",
   "body": [
     {
       "type": "Input.Text",
       "id": "url",
       "label": "%Widget_Template_Label/Url%",
-      "inlineAction": {
-        "type": "Action.Execute",
-        "tooltip": "%Widget_Template_Tooltip/Submit%",
-        "verb": "CheckUrl",
-        "iconUrl": "data:image/png;base64,${submitIcon}"
-      },
       "spacing": "Medium",
       "style": "Url",
       "placeholder": "%Widget_Template_Input/UrlPlaceholder%",
-      "value": "${$root.configuration.url}"
+      "value": "${url}"
+    },
+    {
+      "type": "Input.ChoiceSet",
+      "id": "knownrepo",
+      "label": "Known repositories",
+      "placeholder": "Select a repository",
+      "choices": [
+        {
+          "$data": "${knownRepositories}",
+          "title": "${name}",
+          "value": "${name}"
+        }
+      ]
     },
     {
       "type": "Input.Text",
@@ -100,8 +107,7 @@
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/Save%",
                       "verb": "Save",
-                      "tooltip": "%Widget_Template_Tooltip/Save%",
-                      "isEnabled": "${saveEnabled}"
+                      "tooltip": "%Widget_Template_Tooltip/Save%"
                     },
                     {
                       "type": "Action.Execute",


### PR DESCRIPTION
## Summary of the pull request
This PR simplifies the configuration flow for the Pull Request and Issues widgets. The new flow is the same as the Azure widgets have, with just needing one button click to configure it.

### Demo 


https://github.com/user-attachments/assets/df1e1c28-a20b-4e30-b77c-ea3a9262ce1b


## References and relevant issues

## Detailed description of the pull request / Additional comments
The arrow button that validates the URL was removed and this action is now automatically performed by the save button. 
After clicking the save button, the widget is changed to the loading screen while validating and if there is an error, we go back to the configuration screen with the appropriate error message.
In case of successful validation, we change directly to the content screen.
## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
