### PR TITLE
Fix JsonSerializerOptions

### DIFF
--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPATPage.cs
@@ -11,7 +11,7 @@ internal sealed class EnterpriseServerPATPage : LoginUIPage
     public EnterpriseServerPATPage(Uri hostAddress, string errorText, SecureString inputPAT)
         : base(LoginUIState.EnterpriseServerPATPage)
     {
-        Data = new PageData()
+        Data = new EnterpriseServerPATPageData()
         {
             EnterpriseServerPATPageInputValue = new System.Net.NetworkCredential(string.Empty, inputPAT).Password ?? string.Empty,
             EnterpriseServerPATPageErrorValue = errorText ?? string.Empty,
@@ -22,7 +22,7 @@ internal sealed class EnterpriseServerPATPage : LoginUIPage
         };
     }
 
-    internal sealed class PageData : ILoginUIPageData
+    internal sealed class EnterpriseServerPATPageData : ILoginUIPageData
     {
         public string EnterpriseServerPATPageInputValue { get; set; } = string.Empty;
 
@@ -36,7 +36,7 @@ internal sealed class EnterpriseServerPATPage : LoginUIPage
 
         public string GetJson()
         {
-            return Json.Stringify(this);
+            return Json.Stringify(this, _optionsWithContext);
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/EnterpriseServerPage.cs
@@ -10,7 +10,7 @@ internal sealed class EnterpriseServerPage : LoginUIPage
     public EnterpriseServerPage(Uri? hostAddress, string errorText)
         : base(LoginUIState.EnterpriseServerPage)
     {
-        Data = new PageData()
+        Data = new EnterpriseServerPageData()
         {
             EnterpriseServerInputValue = hostAddress?.ToString() ?? string.Empty,
             EnterpriseServerPageErrorValue = errorText ?? string.Empty,
@@ -21,7 +21,7 @@ internal sealed class EnterpriseServerPage : LoginUIPage
     public EnterpriseServerPage(string hostAddress, string errorText)
         : base(LoginUIState.EnterpriseServerPage)
     {
-        Data = new PageData()
+        Data = new EnterpriseServerPageData()
         {
             EnterpriseServerInputValue = hostAddress,
             EnterpriseServerPageErrorValue = errorText ?? string.Empty,
@@ -29,7 +29,7 @@ internal sealed class EnterpriseServerPage : LoginUIPage
         };
     }
 
-    internal sealed class PageData : ILoginUIPageData
+    internal sealed class EnterpriseServerPageData : ILoginUIPageData
     {
         public string EnterpriseServerInputValue { get; set; } = string.Empty;
 
@@ -40,7 +40,7 @@ internal sealed class EnterpriseServerPage : LoginUIPage
 
         public string GetJson()
         {
-            return Json.Stringify(this);
+            return Json.Stringify(this, _optionsWithContext);
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/JsonSourceGenerationContext.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/JsonSourceGenerationContext.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using static GitHubExtension.DeveloperId.LoginUI.EnterpriseServerPage;
+using static GitHubExtension.DeveloperId.LoginUI.EnterpriseServerPATPage;
+using static GitHubExtension.DeveloperId.LoginUI.LoginFailedPage;
+using static GitHubExtension.DeveloperId.LoginUI.LoginPage;
+using static GitHubExtension.DeveloperId.LoginUI.LoginSucceededPage;
+using static GitHubExtension.DeveloperId.LoginUI.WaitingPage;
+
+namespace GitHubExtension.DeveloperId;
+
+[JsonSerializable(typeof(EnterpriseServerPageData))]
+[JsonSerializable(typeof(EnterpriseServerPATPageData))]
+[JsonSerializable(typeof(LoginFailedPageData))]
+[JsonSerializable(typeof(LoginPageData))]
+[JsonSerializable(typeof(LoginSucceededPageData))]
+[JsonSerializable(typeof(WaitingPageData))]
+internal sealed partial class JsonSourceGenerationContext : JsonSerializerContext
+{
+}

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginFailedPage.cs
@@ -17,7 +17,7 @@ internal sealed class LoginFailedPage : LoginUIPage
     {
         public string GetJson()
         {
-            return Json.Stringify(this);
+            return Json.Stringify(this, _optionsWithContext);
         }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginPage.cs
@@ -10,14 +10,14 @@ internal sealed class LoginPage : LoginUIPage
     public LoginPage()
         : base(LoginUIState.LoginPage)
     {
-        Data = new PageData();
+        Data = new LoginPageData();
     }
 
-    internal sealed class PageData : ILoginUIPageData
+    internal sealed class LoginPageData : ILoginUIPageData
     {
         public string GetJson()
         {
-            return Json.Stringify(this);
+            return Json.Stringify(this, _optionsWithContext);
         }
     }
 

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginSucceededPage.cs
@@ -23,7 +23,7 @@ internal sealed class LoginSucceededPage : LoginUIPage
 
         public string GetJson()
         {
-            return Json.Stringify(this);
+            return Json.Stringify(this, _optionsWithContext);
         }
     }
 }

--- a/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/LoginUIPage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using GitHubExtension.Helpers;
 using Microsoft.Windows.DevHome.SDK;
 
@@ -11,6 +13,14 @@ internal class LoginUIPage
     private readonly string _template;
     private readonly LoginUIState _state;
     private ILoginUIPageData? _data;
+
+    public static readonly JsonSerializerOptions _optionsWithContext = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        IncludeFields = true,
+        TypeInfoResolver = JsonSourceGenerationContext.Default,
+    };
 
     public interface ILoginUIPageData
     {

--- a/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
+++ b/src/GitHubExtension/DeveloperId/LoginUI/WaitingPage.cs
@@ -17,7 +17,7 @@ internal sealed class WaitingPage : LoginUIPage
     {
         public string GetJson()
         {
-            return Json.Stringify(this);
+            return Json.Stringify(this, _optionsWithContext);
         }
     }
 }

--- a/src/GitHubExtension/Helpers/Json.cs
+++ b/src/GitHubExtension/Helpers/Json.cs
@@ -42,14 +42,14 @@ public static class Json
         });
     }
 
-    public static string Stringify<T>(T value)
+    public static string Stringify<T>(T value, JsonSerializerOptions? options = null)
     {
         if (typeof(T) == typeof(bool))
         {
             return value!.ToString()!.ToLowerInvariant();
         }
 
-        return System.Text.Json.JsonSerializer.Serialize(value, _options);
+        return System.Text.Json.JsonSerializer.Serialize(value, options ?? _options);
     }
 
     public static T? ToObject<T>(string json)


### PR DESCRIPTION
## Summary of the pull request
Fixes an issue with JsonSerializerOptions caused by this [breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/reflection-fallback) in .Net8 that is mysteriously not hitting on Dev builds (not just my computer). 

## References and relevant issues
https://github.com/microsoft/devhome/issues/3573

## Detailed description of the pull request / Additional comments
.Net8 requires explicit declaration of TypeInfoResolver in JsonSerializerOptions for complex objects. The failure stack in Canary build was:
*** WARNING: Unable to verify checksum for C:\Program Files\WindowsApps\Microsoft.Windows.DevHomeGitHubExtension.Canary_0.1700.585.0_x64__8wekyb3d8bbwe\System.Text.Json.dll

 Child-SP          RetAddr               Call Site
00 000000c1`197bdfd0 00007ffe`e916b423     KERNELBASE!RaiseException+0x6c
01 000000c1`197be0b0 00007ffe`e916adc9     coreclr!RaiseTheExceptionInternalOnly+0x26b [D:\a\_work\1\s\src\coreclr\vm\excep.cpp @ 2795] 
02 000000c1`197be1c0 00007ffe`89695558     coreclr!IL_Throw+0xb9 [D:\a\_work\1\s\src\coreclr\vm\jithelpers.cpp @ 4247] 
03 000000c1`197be320 00007ffe`db1c1e96     System_Text_Json!System.Text.Json.ThrowHelper.ThrowInvalidOperationException_JsonSerializerIsReflectionDisabled()+0x48
04 000000c1`197be360 00007ffe`db1c102c     System_Text_Json!System.Text.Json.JsonSerializerOptions.ConfigureForJsonSerializer()+0x36
05 000000c1`197be390 00007ffe`dba1fae1     System_Text_Json!System.Text.Json.JsonSerializer.GetTypeInfo(System.Text.Json.JsonSerializerOptions, System.Type)+0x2c
06 000000c1`197be3d0 00007ffe`dba1ff7b     System_Text_Json!System.Text.Json.JsonSerializer.GetTypeInfo[[System.__Canon, System.Private.CoreLib]](System.Text.Json.JsonSerializerOptions)+0x31
07 000000c1`197be420 00007ffe`db9f9c20     System_Text_Json!System.Text.Json.JsonSerializer.Serialize[[System.__Canon, System.Private.CoreLib]](System.__Canon, System.Text.Json.JsonSerializerOptions)+0x2b
08 000000c1`197be460 00007ffe`da92fcd0     GitHubExtension!GitHubExtension.Helpers.Json.Stringify[[System.__Canon, System.Private.CoreLib]](System.__Canon)+0x30
09 000000c1`197be4a0 00007ffe`daa3bedc     GitHubExtension!GitHubExtension.DeveloperId.LoginUIPage.UpdateExtensionAdaptiveCard(Microsoft.Windows.DevHome.SDK.IExtensionAdaptiveCard)+0x30
0a 000000c1`197be4f0 00007ff8`19f77503     Microsoft_Windows_DevHome_SDK_Lib!ABI.Microsoft.Windows.DevHome.SDK.IExtensionAdaptiveCardSession.Do_Abi_Initialize_0(IntPtr, IntPtr, IntPtr*)+0x6c

Fixed using [the recommended way in breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/reflection-fallback)


## Validation steps performed
Ran tests, automated and manually. Couldn't repro original bug on Dev build, but this doesn't break anything on Dev build.

## PR checklist
- [ ] Closes https://github.com/microsoft/devhome/issues/3573
- [ ] Tests passed
