### PR TITLE
Add JsonSerializerIsReflectionEnabledByDefault to props file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -55,4 +55,8 @@
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary of the pull request
Fixes an issue with JsonSerializerOptions caused by this [breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/reflection-fallback) in .Net8 that is mysteriously not hitting on Dev builds (not just my computer).
Similar to https://github.com/microsoft/DevHomeAzureExtension/pull/135/files

## References and relevant issues
Follow up to #426. 

## Detailed description of the pull request / Additional comments
Added JsonSerializerIsReflectionEnabledByDefault.

## Validation steps performed
Tested Dev build.

## PR checklist
- [ ] Closes #432
- [ ] Tests added/passed
- [ ] Documentation updated
