### PR TITLE
Fix Json serializer reflection

### DIFF
--- a/src/GitHubExtensionServer/GitHubExtensionServer.csproj
+++ b/src/GitHubExtensionServer/GitHubExtensionServer.csproj
@@ -22,6 +22,7 @@
     <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <TrimMode>partial</TrimMode>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>


### PR DESCRIPTION
## Summary of the pull request
Sets JsonSerializer reflection default back to .Net 7 compat.
 
## References and relevant issues
Same fix in Azure Extension Repo: https://github.com/microsoft/DevHomeAzureExtension/pull/135

## Detailed description of the pull request / Additional comments
Migration to .Net 8 changed the Json Serializer reflection default. This sets it back to .Net 7 for compat. There may be work here in the future to be able to disable this, but this will get the extension working again.

Note that this does not repro on Debug builds, must build Release to see the bug and verify fix.

## Validation steps performed
* Verified bug repros on Release build and does not repro with the fix.

## PR checklist
- [x] Closes #432
- [x] Tests added/passed
- [x] Documentation updated
