### PR TITLE
Default titles not saved anymore for widgets

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubIssuesWidget.cs
@@ -152,7 +152,7 @@ internal sealed class GitHubIssuesWidget : GitHubRepositoryWidget
 
             issuesData.Add("issues", issuesArray);
             issuesData.Add("selected_repo", repository?.FullName ?? string.Empty);
-            issuesData.Add("widgetTitle", WidgetTitle);
+            issuesData.Add("widgetTitle", GetActualTitle());
             issuesData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
             issuesData.Add("issues_icon_data", _issuesIconData);
 

--- a/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubPullsWidget.cs
@@ -123,7 +123,7 @@ internal sealed class GitHubPullsWidget : GitHubRepositoryWidget
 
             pullsData.Add("pulls", pullsArray);
             pullsData.Add("selected_repo", repository?.FullName ?? string.Empty);
-            pullsData.Add("widgetTitle", WidgetTitle);
+            pullsData.Add("widgetTitle", GetActualTitle());
             pullsData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
             pullsData.Add("pulls_icon_data", _pullsIconData);
 

--- a/src/GitHubExtension/Widgets/GitHubReleasesWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReleasesWidget.cs
@@ -121,7 +121,7 @@ internal sealed class GitHubReleasesWidget : GitHubRepositoryWidget
 
             releasesData.Add("releases", releasesArray);
             releasesData.Add("selected_repo", repository?.FullName ?? string.Empty);
-            releasesData.Add("widgetTitle", WidgetTitle);
+            releasesData.Add("widgetTitle", GetActualTitle());
             releasesData.Add("is_loading_data", DataState == WidgetDataState.Unknown);
             releasesData.Add("releases_icon_data", _releasesIconData);
 

--- a/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubRepositoryWidget.cs
@@ -143,17 +143,11 @@ public abstract class GitHubRepositoryWidget : GitHubWidget
         }
 
         GetTitleFromDataObject(dataObj);
-        if (string.IsNullOrEmpty(WidgetTitle))
-        {
-            try
-            {
-                WidgetTitle = GetRepositoryFromUrl(RepositoryUrl).FullName;
-            }
-            catch
-            {
-                WidgetTitle = string.Empty;
-            }
-        }
+    }
+
+    protected string GetActualTitle()
+    {
+        return string.IsNullOrEmpty(WidgetTitle) ? GetRepositoryFromUrl(RepositoryUrl).FullName : WidgetTitle;
     }
 
     protected override void ResetWidgetInfoFromState()

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -57,11 +57,17 @@ internal abstract class GitHubUserWidget : GitHubWidget
 
     protected void UpdateTitle(JsonNode dataObj)
     {
-        GetTitleFromDataObject(dataObj);
-        if (string.IsNullOrEmpty(WidgetTitle))
+        if (dataObj == null)
         {
-            WidgetTitle = UserName;
+            return;
         }
+
+        GetTitleFromDataObject(dataObj);
+    }
+
+    protected string GetActualTitle()
+    {
+        return string.IsNullOrEmpty(WidgetTitle) ? UserName : WidgetTitle;
     }
 
     protected override void ResetWidgetInfoFromState()
@@ -249,7 +255,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             { "openCount", 0 },
             { "items", new JsonArray() },
             { "userName", UserName },
-            { "widgetTitle", WidgetTitle },
+            { "widgetTitle", GetActualTitle() },
             { "titleIconUrl", GetTitleIconData() },
             { "is_loading_data", true },
         };
@@ -302,7 +308,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
             issuesData.Add("items", issuesArray);
             issuesData.Add("userName", UserName);
             issuesData.Add("titleIconUrl", GetTitleIconData());
-            issuesData.Add("widgetTitle", WidgetTitle);
+            issuesData.Add("widgetTitle", GetActualTitle());
 
             LastUpdated = DateTime.Now;
             ContentData = issuesData.ToJsonString();


### PR DESCRIPTION
## Summary of the pull request
When the user saves a widget with not title, a default title is displayed for them. For repository widgets, it is the name of the repository. For user widgets, it is the username. This title was being saved in the widget data, but resulted is some QoL issues. This PR makes these default titles to not be saved anymore, and just rendered in the content is loaded to be presented.
## References and relevant issues
#430 
## Detailed description of the pull request / Additional comments
As the issue above describes, when the user saves a repository widget, it sets the title to be its repository's full name. When the user customizes this widget and changes to another repository, the previous title keeps saved, requiring the user to actively change or erase the title.
This default title does not need to be saved as it is a information that we get on time from the widget's information. So it is the best choice to not save it in the widget's data string and just generate the string when it is needed.
## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
