### PR TITLE
Review requested widget now is customizable

### DIFF
--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json.Nodes;
-using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
-using Microsoft.Windows.Widgets.Providers;
 using Octokit;
 
 namespace GitHubExtension.Widgets;
 
 internal sealed class GitHubReviewWidget : GitHubUserWidget
 {
+    protected override string DefaultShowCategory => "PullRequests";
+
     protected override string GetTitleIconData()
     {
         return IconLoader.GetIconAsBase64("pulls.png");

--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -11,11 +11,9 @@ namespace GitHubExtension.Widgets;
 
 internal sealed class GitHubReviewWidget : GitHubUserWidget
 {
-    public GitHubReviewWidget()
-        : base()
+    protected override string GetTitleIconData()
     {
-        // This widget does not allow customization, so this value will not change.
-        ShowCategory = SearchCategory.PullRequests;
+        return IconLoader.GetIconAsBase64("pulls.png");
     }
 
     public override void RequestContentData()
@@ -25,41 +23,21 @@ internal sealed class GitHubReviewWidget : GitHubUserWidget
         RequestContentData(request);
     }
 
-    protected override string GetTitleIconData()
-    {
-        return IconLoader.GetIconAsBase64("pulls.png");
-    }
-
-    // This widget does not have "ShowCategory" as a variable.
-    // So we override this method to not care about this data.
-    protected override void ResetWidgetInfoFromState()
-    {
-        base.ResetWidgetInfoFromState();
-        ShowCategory = SearchCategory.PullRequests;
-    }
-
-    // Overriding this method because this widget only cares about the account.
     public override void OnActionInvoked(WidgetActionInvokedArgs actionInvokedArgs)
     {
+        // This widget does not have the ShowCategory
+        // property for the user to input,
+        // so we always put it to PullRequest here.
         if (actionInvokedArgs.Verb == "Submit")
         {
             var data = actionInvokedArgs.Data;
             var dataObject = JsonNode.Parse(data);
 
-            if (dataObject == null)
+            if (dataObject != null)
             {
-                return;
+                dataObject["showCategory"] = "PullRequests";
+                SubmitAction(dataObject.ToString());
             }
-
-            DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
-            UpdateTitle(dataObject);
-
-            ConfigurationData = data;
-
-            // If we got here during the customization flow, we need to LoadContentData again
-            // so we can show the loading page rather than stale data.
-            LoadContentData();
-            UpdateActivityState();
         }
         else
         {

--- a/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubReviewWidget.cs
@@ -23,28 +23,6 @@ internal sealed class GitHubReviewWidget : GitHubUserWidget
         RequestContentData(request);
     }
 
-    public override void OnActionInvoked(WidgetActionInvokedArgs actionInvokedArgs)
-    {
-        // This widget does not have the ShowCategory
-        // property for the user to input,
-        // so we always put it to PullRequest here.
-        if (actionInvokedArgs.Verb == "Submit")
-        {
-            var data = actionInvokedArgs.Data;
-            var dataObject = JsonNode.Parse(data);
-
-            if (dataObject != null)
-            {
-                dataObject["showCategory"] = "PullRequests";
-                SubmitAction(dataObject.ToString());
-            }
-        }
-        else
-        {
-            base.OnActionInvoked(actionInvokedArgs);
-        }
-    }
-
     public override string GetTemplatePath(WidgetPageState page)
     {
         return page switch

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -135,28 +135,33 @@ internal abstract class GitHubUserWidget : GitHubWidget
         base.OnCustomizationRequested(customizationRequestedArgs);
     }
 
+    protected void SubmitAction(string data)
+    {
+        var dataObject = JsonNode.Parse(data);
+
+        if (dataObject == null)
+        {
+            return;
+        }
+
+        ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
+        DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
+        UpdateTitle(dataObject);
+
+        ConfigurationData = data;
+
+        // If we got here during the customization flow, we need to LoadContentData again
+        // so we can show the loading page rather than stale data.
+        LoadContentData();
+        UpdateActivityState();
+    }
+
     public override void OnActionInvoked(WidgetActionInvokedArgs actionInvokedArgs)
     {
         if (actionInvokedArgs.Verb == "Submit")
         {
             var data = actionInvokedArgs.Data;
-            var dataObject = JsonNode.Parse(data);
-
-            if (dataObject == null)
-            {
-                return;
-            }
-
-            ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
-            DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
-            UpdateTitle(dataObject);
-
-            ConfigurationData = data;
-
-            // If we got here during the customization flow, we need to LoadContentData again
-            // so we can show the loading page rather than stale data.
-            LoadContentData();
-            UpdateActivityState();
+            SubmitAction(data);
         }
         else
         {

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -135,33 +135,28 @@ internal abstract class GitHubUserWidget : GitHubWidget
         base.OnCustomizationRequested(customizationRequestedArgs);
     }
 
-    protected void SubmitAction(string data)
-    {
-        var dataObject = JsonNode.Parse(data);
-
-        if (dataObject == null)
-        {
-            return;
-        }
-
-        ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
-        DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
-        UpdateTitle(dataObject);
-
-        ConfigurationData = data;
-
-        // If we got here during the customization flow, we need to LoadContentData again
-        // so we can show the loading page rather than stale data.
-        LoadContentData();
-        UpdateActivityState();
-    }
-
     public override void OnActionInvoked(WidgetActionInvokedArgs actionInvokedArgs)
     {
         if (actionInvokedArgs.Verb == "Submit")
         {
             var data = actionInvokedArgs.Data;
-            SubmitAction(data);
+            var dataObject = JsonNode.Parse(data);
+
+            if (dataObject == null)
+            {
+                return;
+            }
+
+            ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
+            DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
+            UpdateTitle(dataObject);
+
+            ConfigurationData = data;
+
+            // If we got here during the customization flow, we need to LoadContentData again
+            // so we can show the loading page rather than stale data.
+            LoadContentData();
+            UpdateActivityState();
         }
         else
         {

--- a/src/GitHubExtension/Widgets/GitHubUserWidget.cs
+++ b/src/GitHubExtension/Widgets/GitHubUserWidget.cs
@@ -19,6 +19,8 @@ internal abstract class GitHubUserWidget : GitHubWidget
 
     protected SearchCategory ShowCategory { get; set; } = SearchCategory.Unknown;
 
+    protected virtual string DefaultShowCategory => string.Empty;
+
     private string _userName = string.Empty;
 
     protected string UserName
@@ -115,7 +117,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
         try
         {
             dataObject ??= JsonNode.Parse(ConfigurationData);
-            ShowCategory = EnumHelper.StringToSearchCategory(dataObject!["showCategory"]?.GetValue<string>() ?? string.Empty);
+            ShowCategory = EnumHelper.StringToSearchCategory(dataObject!["showCategory"]?.GetValue<string>() ?? DefaultShowCategory);
             DeveloperLoginId = dataObject!["account"]?.GetValue<string>() ?? string.Empty;
             UpdateTitle(dataObject);
         }
@@ -147,7 +149,7 @@ internal abstract class GitHubUserWidget : GitHubWidget
                 return;
             }
 
-            ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? string.Empty);
+            ShowCategory = EnumHelper.StringToSearchCategory(dataObject["showCategory"]?.GetValue<string>() ?? DefaultShowCategory);
             DeveloperLoginId = dataObject["account"]?.GetValue<string>() ?? string.Empty;
             UpdateTitle(dataObject);
 

--- a/src/GitHubExtension/Widgets/Templates/GitHubReviewConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubReviewConfigurationTemplate.json
@@ -24,19 +24,6 @@
       "value": "${widgetTitle}"
     },
     {
-      "type": "Input.ChoiceSet",
-      "id": "showCategory",
-      "isMultiSelect": false,
-      "isVisible": false,
-      "value": "PullRequests",
-      "choices": [
-        {
-          "title": "%Widget_Template/PullRequests%",
-          "value": "PullRequests"
-        }
-      ]
-    },
-    {
       "type": "ColumnSet",
       "columns": [
         {

--- a/src/GitHubExtension/Widgets/Templates/GitHubReviewConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubReviewConfigurationTemplate.json
@@ -24,6 +24,19 @@
       "value": "${widgetTitle}"
     },
     {
+      "type": "Input.ChoiceSet",
+      "id": "showCategory",
+      "isMultiSelect": false,
+      "isVisible": false,
+      "value": "PullRequests",
+      "choices": [
+        {
+          "title": "%Widget_Template/PullRequests%",
+          "value": "PullRequests"
+        }
+      ]
+    },
+    {
       "type": "ColumnSet",
       "columns": [
         {

--- a/src/GitHubExtensionServer/Package-Can.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Can.appxmanifest
@@ -212,7 +212,7 @@
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="false">
+                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />

--- a/src/GitHubExtensionServer/Package-Dev.appxmanifest
+++ b/src/GitHubExtensionServer/Package-Dev.appxmanifest
@@ -212,7 +212,7 @@
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="false">
+                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />

--- a/src/GitHubExtensionServer/Package.appxmanifest
+++ b/src/GitHubExtensionServer/Package.appxmanifest
@@ -212,7 +212,7 @@
                       </LightMode>
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="false">
+                  <Definition Id="GitHub_Reviews" DisplayName="ms-resource:Widget_DisplayName_Reviews" Description="ms-resource:Widget_Description_Reviews" IsCustomizable="true">
                     <Capabilities>
                       <Capability>
                         <Size Name="medium" />


### PR DESCRIPTION
## Summary of the pull request
This PR makes the "Review Requested" widget customizable.
## References and relevant issues

## Detailed description of the pull request / Additional comments
This PR changes the code of the Review Request widget to make it similar to the other User widgets. The only difference is that for this widget, the `ShowCategory` property is always set to `PullRequests`.
For that, one of the simplest ways is to have a ghost input in the configuration template that sets this variable always, and then no further changes are needed on the code. 
Other options would be to inject it in the Json string received by the widget, or rewrite the action handler in this widget giving up of the inheritance capabilities.
For this PR, the first option was chosen.
## Validation steps performed

## PR checklist
- [ ] Closes #349
- [ ] Tests added/passed
- [ ] Documentation updated
