### PR TITLE
Add HttpRequestException expected exception handling

### DIFF
--- a/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
+++ b/src/GitHubExtension/DataManager/GitHubDataManagerUpdate.cs
@@ -25,6 +25,15 @@ public partial class GitHubDataManager
         {
             await UpdateDeveloperPullRequests();
         }
+        catch (HttpRequestException httpEx)
+        {
+            // HttpRequestExceptions can happen when internet connection is
+            // down or various other network issues unrelated to this update.
+            // This is not an error in the extension or anything we can
+            // address. Log a warning so it is understood why the update did
+            // not occur, but otherwise keep the log clean.
+            _log.Warning($"Http Request Exception: {httpEx.Message}");
+        }
         catch (Exception ex)
         {
             _log.Error(ex, "Update failed unexpectedly.");


### PR DESCRIPTION
## Summary of the pull request

Adds exception handling to not spam detailed error stack when we have an HttpRequest exception. This keeps the log clean and avoids giving us false alarm exception spam when unrelated network issues happen, such as DNS resolution problems or simply no internet connection.

## References and relevant issues
Observed such false alarm spam in: https://github.com/microsoft/devhome/issues/3778

## Detailed description of the pull request / Additional comments

* Adds exception catches specifically for HttpRequestException and treats them as warnings and does not log the exception.

## Validation steps performed

* Built and deployed fix with forced HttpRequestException thrown to verify handling. Confirmed log has warnings and no exception stack dump and no errors.

## PR checklist
- [x] Closes #444
- [x] Tests added/passed
- [x] Documentation updated
