### PR TITLE
Fix Releases Widget

### DIFF
--- a/src/GitHubExtension/Widgets/Templates/GitHubReleasesConfigurationTemplate.json
+++ b/src/GitHubExtension/Widgets/Templates/GitHubReleasesConfigurationTemplate.json
@@ -7,16 +7,10 @@
       "type": "Input.Text",
       "id": "url",
       "label": "%Widget_Template_Label/Url%",
-      "inlineAction": {
-        "type": "Action.Execute",
-        "tooltip": "%Widget_Template_Tooltip/Submit%",
-        "verb": "CheckUrl",
-        "iconUrl": "data:image/png;base64,${submitIcon}"
-      },
       "spacing": "Medium",
       "style": "Url",
       "placeholder": "%Widget_Template_Input/UrlPlaceholder%",
-      "value": "${$root.configuration.url}"
+      "value": "${url}"
     },
     {
       "type": "Input.Text",
@@ -87,8 +81,7 @@
                       "type": "Action.Execute",
                       "title": "%Widget_Template_Button/Save%",
                       "verb": "Save",
-                      "tooltip": "%Widget_Template_Tooltip/Save%",
-                      "isEnabled": "${$root.saveEnabled}"
+                      "tooltip": "%Widget_Template_Tooltip/Save%"
                     },
                     {
                       "type": "Action.Execute",


### PR DESCRIPTION
## Summary of the pull request

Fix for Releases widget configuration not displayed.
Broken by https://github.com/microsoft/devhomegithubextension/pull/424

![image](https://github.com/user-attachments/assets/4bc98d1e-c069-4aac-962c-4d989eb2cf81)
0.18 vs dev

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
