### PR TITLE
Remove ClCompile from csproj

### DIFF
--- a/src/GitHubExtension/GitHubExtension.csproj
+++ b/src/GitHubExtension/GitHubExtension.csproj
@@ -9,13 +9,6 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
-      <SpectreMitigation>Spectre</SpectreMitigation>
-    </ClCompile>
-  </ItemDefinitionGroup>
-
   <ItemGroup>
     <None Remove="Widgets\Templates\GitHubAssignedConfigurationTemplate.json" />
     <None Remove="Widgets\Templates\GitHubAssignedTemplate.json" />

--- a/src/GitHubExtensionServer/GitHubExtensionServer.csproj
+++ b/src/GitHubExtensionServer/GitHubExtensionServer.csproj
@@ -29,13 +29,6 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
-      <SpectreMitigation>Spectre</SpectreMitigation>
-    </ClCompile>
-  </ItemDefinitionGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\GitHubExtension\GitHubExtension.csproj" />
   </ItemGroup>

--- a/src/Telemetry/GitHubExtension.Telemetry.csproj
+++ b/src/Telemetry/GitHubExtension.Telemetry.csproj
@@ -7,13 +7,6 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
-      <SpectreMitigation>Spectre</SpectreMitigation>
-    </ClCompile>
-  </ItemDefinitionGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />


### PR DESCRIPTION
This item doesn't do anything in a csproj. It only applies to C++.

cc @EricJohnson327